### PR TITLE
Enumとして定義されているプロパティをmodel内で定数として扱う

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "license": "",
   "main": "dist/index.js",
-  "repository": "MtBlue81/openapi-to-normalizr",
+  "repository": "eightcard/openapi-to-normalizr",
   "scripts": {
     "build:dist": "npm run eslint && npm test && babel -d dist --env-name=development src/lib/**/*[^test].js",
     "build:sample": "webpack --config examples/webpack.config.babel.js --progress",

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -266,11 +266,11 @@ function getFlowTypes() {
 
 function getDefaults() {
   if (!this.default) { return 'undefined'; }
-  if(this.enumObjects) {
-    for(const enumValueObject of this.enumObjects) {
+  if (this.enumObjects) {
+    for (const enumValueObject of this.enumObjects) {
       const isSameName = getPropertyName(enumValueObject.name) === this.propertyName;
       const isSameValue = enumValueObject.value === this.default;
-      if(isSameName && isSameValue) return enumValueObject.name;
+      if (isSameName && isSameValue) return enumValueObject.name;
     }
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -125,7 +125,7 @@ class ModelGenerator {
         type: this.generateTypeFrom(prop, dependencySchema[name]),
         alias: prop['x-attribute-as'],
         required: prop.required === true,
-        isEnum: this.isEnum(prop.enum),
+        isEnum: new Boolean(prop.enum),
         isValueString: prop.type === 'string',
         propertyName: name,
         enumValueNames: this.getEnumNames(this.attributeConverter(name), prop.enum),
@@ -135,13 +135,6 @@ class ModelGenerator {
         return ret;
       }, base);
     });
-  }
-
-  isEnum(enums) {
-    if(enums) {
-      return true;
-    }
-    return false;
   }
 
   getEnumNames(name, enums) {

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -272,6 +272,11 @@ function getFlowTypes() {
 
 function getDefaults() {
   if (!this.default) { return 'undefined'; }
+  if(this.enumValueNames) {
+    for(const enumValueName of this.enumValueNames) {
+      if(enumValueName.indexOf(this.default) !== -1) return enumValueName;
+    }
+  }
   return this.type === 'string' ? `'${this.default}'` : this.default;
 }
 

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -148,13 +148,12 @@ class ModelGenerator {
     if(!enums) {
       return;
     }
-    // console.log(name); // eslint-disable-line no-console
-    const nameList = [];
-    for(let i = 0; i < enums.length; i++) {
-      const enumName = `${_.camelCase(name)}_${enums[i]}`;
-      nameList.push(enumName);
-    }
-    return nameList;
+
+    const nameMap = enums.map((current) => {
+      return `${_.camelCase(name)}_${current}`
+    });
+
+    return nameMap;
   }
 
   generateTypeFrom(prop, definition) {

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -128,7 +128,7 @@ class ModelGenerator {
         isEnum: new Boolean(prop.enum), // eslint-disable-line no-new-wrappers
         isValueString: prop.type === 'string',
         propertyName: name,
-        enumValueNames: this.getEnumNames(this.attributeConverter(name), prop.enum),
+        enumValueNames: this.getEnumNames(name, prop.enum),
       };
       return this.constructor.templatePropNames.reduce((ret, key) => {
         ret[key] = ret[key] || properties[name][key];

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -278,7 +278,9 @@ function getDefaults() {
 
 function getPropertyName(name) {
   const snakeCaseName = _.snakeCase(name);
-  return snakeCaseName.split('_').slice(0, 2).join('_');
+  const splitted = snakeCaseName.split('_');
+  splitted.length -= 1; // 定数名を構成する文字列のうち、最後のものが値を示すので逆変換ではこれを取り払う
+  return splitted.join('_');
 }
 
 module.exports = ModelGenerator;

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -138,11 +138,12 @@ class ModelGenerator {
   }
 
   getEnumObjects(name, enums) {
-    if(!enums) {
+    if (!enums) {
       return;
     }
     return enums.map((current) => {
-      const enumName = `${_.upperCase(name).split(' ').join('_')}_${_.upperCase(current)}`;
+      const convertedName = _.upperCase(name).split(' ').join('_');
+      const enumName = `${convertedName}_${_.upperCase(current)}`;
       return {
         'name': enumName,
         'value': current,
@@ -267,10 +268,16 @@ function getFlowTypes() {
 function getDefaults() {
   if (!this.default) { return 'undefined'; }
   if (this.enumObjects) {
-    for (const enumValueObject of this.enumObjects) {
-      const isSameName = getPropertyName(enumValueObject.name) === this.propertyName;
-      const isSameValue = enumValueObject.value === this.default;
-      if (isSameName && isSameValue) return enumValueObject.name;
+    for (const enumObject of this.enumObjects) {
+
+      /**
+       * enumをdefaultPropsの値として用いる条件は次の2つ
+       * 1. enumObject.nameを逆変換して得られる文字列がプロパティ名と一致している場合（名前の一致）
+       * 2. enumObject.valueがもともとのthis.defaultと一致している場合（値の一致）
+       */
+      const isSameName = getPropertyName(enumObject.name) === this.propertyName;
+      const isSameValue = enumObject.value === this.default;
+      if (isSameName && isSameValue) return enumObject.name;
     }
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -120,7 +120,6 @@ class ModelGenerator {
 
   _convertPropForTemplate(properties, dependencySchema = {}) {
     return _.map(properties, (prop, name) => {
-      console.log(prop);
       const base = {
         name: () => this.attributeConverter(name),
         type: this.generateTypeFrom(prop, dependencySchema[name]),
@@ -129,7 +128,7 @@ class ModelGenerator {
         isEnum: new Boolean(prop.enum), // eslint-disable-line no-new-wrappers
         isValueString: prop.type === 'string',
         propertyName: name,
-        enumValueObjects: this.getEnumObjects(name, prop.enum),
+        enumObjects: this.getEnumObjects(name, prop.enum),
       };
       return this.constructor.templatePropNames.reduce((ret, key) => {
         ret[key] = ret[key] || properties[name][key];
@@ -149,7 +148,6 @@ class ModelGenerator {
         'value': current,
       };
     });
-    // console.log(enumMap); // eslint-disable-line no-console
     return enumMap;
   }
 
@@ -228,12 +226,12 @@ class ModelGenerator {
 }
 
 function getPropTypes() {
-  return _getPropTypes(this.type, this.enum, this.enumValueObjects);
+  return _getPropTypes(this.type, this.enum, this.enumObjects);
 }
 
-function _getPropTypes(type, enums, enumValueObjects) {
+function _getPropTypes(type, enums, enumObjects) {
   if (enums) {
-    const nameMap = enumValueObjects.map((current) => current.name);
+    const nameMap = enumObjects.map((current) => current.name);
     return `PropTypes.oneOf([${nameMap.join(', ')}])`;
   }
   switch(type) {
@@ -269,8 +267,8 @@ function getFlowTypes() {
 
 function getDefaults() {
   if (!this.default) { return 'undefined'; }
-  if(this.enumValueObjects) {
-    for(const enumValueObject of this.enumValueObjects) {
+  if(this.enumObjects) {
+    for(const enumValueObject of this.enumObjects) {
       if(getPropertyName(enumValueObject.name) === this.propertyName) return enumValueObject.name;
     }
   }

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -128,7 +128,7 @@ class ModelGenerator {
         isEnum: Boolean(prop.enum),
         isValueString: prop.type === 'string',
         propertyName: name,
-        enumObjects: this.getEnumObjects(name, prop.enum),
+        enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum),
       };
       return this.constructor.templatePropNames.reduce((ret, key) => {
         ret[key] = ret[key] || properties[name][key];
@@ -142,7 +142,7 @@ class ModelGenerator {
       return;
     }
     return enums.map((current) => {
-      const enumName = `${_.upperCase(_.camelCase(name)).split(' ').join('_')}_${_.upperCase(current)}`;
+      const enumName = `${_.upperCase(name).split(' ').join('_')}_${_.upperCase(current)}`;
       return {
         'name': enumName,
         'value': current,
@@ -268,7 +268,9 @@ function getDefaults() {
   if (!this.default) { return 'undefined'; }
   if(this.enumObjects) {
     for(const enumValueObject of this.enumObjects) {
-      if(getPropertyName(enumValueObject.name) === this.propertyName) return enumValueObject.name;
+      const isSameName = getPropertyName(enumValueObject.name) === this.propertyName;
+      const isSameValue = enumValueObject.value === this.default;
+      if(isSameName && isSameValue) return enumValueObject.name;
     }
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -141,14 +141,13 @@ class ModelGenerator {
     if(!enums) {
       return;
     }
-    const enumMap = enums.map((current) => {
+    return enums.map((current) => {
       const enumName = `${_.upperCase(_.camelCase(name)).split(' ').join('_')}_${_.upperCase(current)}`;
       return {
         'name': enumName,
         'value': current,
       };
     });
-    return enumMap;
   }
 
   generateTypeFrom(prop, definition) {

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -97,7 +97,6 @@ class ModelGenerator {
       name, idAttribute: this._prepareIdAttribute(idAttribute),
       usePropTypes: this.usePropType,
       useFlow: this.useFlow,
-      // enumObjects: getEnumObjects(),
       props: this._convertPropForTemplate(properties, dependencySchema),
       specName: this.specName,
       schema: objectToTemplateValue(changeFormat(dependencySchema, this.attributeConverter)),

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -236,8 +236,7 @@ function getPropTypes() {
 
 function _getPropTypes(type, enums, enumValueNames) {
   if (enums) {
-    const nameList = enumValueNames;
-    return `PropTypes.oneOf([${nameList.join(', ')}])`;
+    return `PropTypes.oneOf([${enumValueNames.join(', ')}])`;
   }
   switch(type) {
     case 'integer':

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -269,25 +269,10 @@ function getDefaults() {
   if (!this.default) { return 'undefined'; }
   if (this.enumObjects) {
     for (const enumObject of this.enumObjects) {
-
-      /**
-       * enumをdefaultPropsの値として用いる条件は次の2つ
-       * 1. enumObject.nameを逆変換して得られる文字列がプロパティ名と一致している場合（名前の一致）
-       * 2. enumObject.valueがもともとのthis.defaultと一致している場合（値の一致）
-       */
-      const isSameName = getPropertyName(enumObject.name) === this.propertyName;
-      const isSameValue = enumObject.value === this.default;
-      if (isSameName && isSameValue) return enumObject.name;
+      if (enumObject.value === this.default) return enumObject.name;
     }
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;
-}
-
-function getPropertyName(name) {
-  const snakeCaseName = _.snakeCase(name);
-  const splitted = snakeCaseName.split('_');
-  splitted.length -= 1; // 定数名を構成する文字列のうち、最後のものが値を示すので逆変換ではこれを取り払う
-  return splitted.join('_');
 }
 
 module.exports = ModelGenerator;

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -125,7 +125,7 @@ class ModelGenerator {
         type: this.generateTypeFrom(prop, dependencySchema[name]),
         alias: prop['x-attribute-as'],
         required: prop.required === true,
-        isEnum: new Boolean(prop.enum), // eslint-disable-line no-new-wrappers
+        isEnum: Boolean(prop.enum),
         isValueString: prop.type === 'string',
         propertyName: name,
         enumObjects: this.getEnumObjects(name, prop.enum),

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -1,4 +1,4 @@
-const _ = require('lodash'); // eslint-disable-line implicit-arrow-linebreak
+const _ = require('lodash');
 const path = require('path');
 const {
   parseSchema, schemaName, render, objectToTemplateValue, applyRequired, getIdAttribute,
@@ -125,7 +125,7 @@ class ModelGenerator {
         type: this.generateTypeFrom(prop, dependencySchema[name]),
         alias: prop['x-attribute-as'],
         required: prop.required === true,
-        isEnum: new Boolean(prop.enum),
+        isEnum: new Boolean(prop.enum), // eslint-disable-line no-new-wrappers
         isValueString: prop.type === 'string',
         propertyName: name,
         enumValueNames: this.getEnumNames(this.attributeConverter(name), prop.enum),

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -127,6 +127,7 @@ class ModelGenerator {
         required: prop.required === true,
         isEnum: this.isEnum(prop.enum),
         isValueString: prop.type === 'string',
+        propertyName: name,
         enumValueNames: this.getEnumNames(this.attributeConverter(name), prop.enum),
       };
       return this.constructor.templatePropNames.reduce((ret, key) => {
@@ -147,6 +148,7 @@ class ModelGenerator {
     if(!enums) {
       return;
     }
+    // console.log(name); // eslint-disable-line no-console
     const nameList = [];
     for(let i = 0; i < enums.length; i++) {
       const enumName = `${_.camelCase(name)}_${enums[i]}`;
@@ -272,11 +274,15 @@ function getDefaults() {
   if (!this.default) { return 'undefined'; }
   if(this.enumValueNames) {
     for(const enumValueName of this.enumValueNames) {
-      if(enumValueName.indexOf(this.default) !== -1) return enumValueName;
+      if(getPropertyName(enumValueName) === this.propertyName) return enumValueName;
     }
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;
 }
 
+function getPropertyName(name) {
+  const camelCaseName = name.split('_')[0];
+  return _.snakeCase(camelCaseName);
+}
 
 module.exports = ModelGenerator;

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -13,6 +13,12 @@ import isArray from 'lodash/isArray';
 import {{#useFlow}}{{name}}, {{/useFlow}}{ schema as {{schemaName}} {{#usePropTypes}}, propTypes as {{name}}PropType{{/usePropTypes}} } from './{{&filePath}}';
 {{/importList}}
 
+{{#props}}
+{{#enum}}
+export const {{name}}_{{.}} = {{#isValueString}}'{{.}}'{{/isValueString}}{{^isValueString}}{{.}}{{/isValueString}};
+{{/enum}}
+{{/props}}
+
 const defaultValues = {
 {{#props}}
   {{&name}}: {{&getDefaults}},

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -14,9 +14,9 @@ import {{#useFlow}}{{name}}, {{/useFlow}}{ schema as {{schemaName}} {{#usePropTy
 {{/importList}}
 
 {{#props}}
-{{#enumValueObjects}}
+{{#enumObjects}}
 export const {{name}} = {{#isValueString}}'{{value}}'{{/isValueString}}{{^isValueString}}{{value}}{{/isValueString}};
-{{/enumValueObjects}}
+{{/enumObjects}}
 {{/props}}
 
 const defaultValues = {

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -14,9 +14,9 @@ import {{#useFlow}}{{name}}, {{/useFlow}}{ schema as {{schemaName}} {{#usePropTy
 {{/importList}}
 
 {{#props}}
-{{#enum}}
-export const {{name}}_{{.}} = {{#isValueString}}'{{.}}'{{/isValueString}}{{^isValueString}}{{.}}{{/isValueString}};
-{{/enum}}
+{{#enumValueObjects}}
+export const {{name}} = {{#isValueString}}'{{value}}'{{/isValueString}}{{^isValueString}}{{value}}{{/isValueString}};
+{{/enumValueObjects}}
 {{/props}}
 
 const defaultValues = {


### PR DESCRIPTION
## 背景
これまで、API定義書でEnumとして定義されているプロパティは生成されたmodel内で値が直接参照されていたが、これを定数として定義するように改変する。

## See
https://github.com/eightcard/openapi-to-normalizr/issues/11

## 実装
- Enumで定義されているプロパティをmodel内で以下のように定義するように改変
```
export const <property名>_<enumの値> = <enumの値>
```

- `PropTypes.oneOf` の引数にEnumの値をそのまま使うのではなく、上記で定義した定数を使用するよう改変

以下は実際に作成したmodel (_pet.js) である
``` _pet.js
/* eslint-disable */
/**
 * generated from API definition file 
 */

import PropTypes from 'prop-types';
import ImmutablePropTypes from 'react-immutable-proptypes';
import { Record, List } from 'immutable';
import { schema as _schema, denormalize as _denormalize } from 'normalizr';
import isArray from 'lodash/isArray';
import { schema as PersonSchema , propTypes as PersonPropType } from './person';

export const objectType_Dog = 'Dog';
export const objectType_Cat = 'Cat';

const defaultValues = {
  objectType: objectType_Cat,
  name: undefined,
  tag: 'no tag',
  id: undefined,
  owner: undefined,
};

export const schema = new _schema.Entity('Pet', {}, {idAttribute: 'id'});
schema.define({
  owner: PersonSchema
});

export const propTypesObject = {
  objectType: PropTypes.oneOf([objectType_Dog, objectType_Cat]).isRequired,
  name: PropTypes.string.isRequired,
  tag: PropTypes.string,
  id: PropTypes.number.isRequired,
  owner: PersonPropType,
};
export const propTypes = PropTypes.shape(propTypesObject);

/**
 * @params ids : Pet's id[s]
 * @params entities : all entities that need to denormalize ids
 */
export const denormalize = (ids, entities) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);

export default class Pet extends Record(defaultValues) {
  static denoromalize(id, entities) {
    return denormalize(id, entities);
  }
}
```