### PR TITLE
modelsの出力を階層化する

### DIFF
--- a/bin/generatemodels
+++ b/bin/generatemodels
@@ -27,6 +27,7 @@ if (_.isEmpty(specFiles)) {
 }
 
 const outputDir = config.outputDir || 'dist';
+const outputInheritDir = config.outputInheritDir || 'dist';
 const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
 const nameList = [];
 let isV2;
@@ -37,12 +38,13 @@ Promise.all(
   models = _.merge(...models);
   const modelGenerator = new ModelGenerator({
     outputDir,
+    outputInheritDir,
     templatePath: config.templates,
     usePropType: config.usePropType,
     useFlow: config.useFlow,
     isV2, attributeConverter,
   });
-  mkdirpPromise(outputDir).then(() => {
+  mkdirpPromise(outputInheritDir).then(() => {
     Promise.all(_.map(models, (model, name) => modelGenerator.writeModel(model, name))).then((modelNames) => {
       modelGenerator.writeIndex(_.uniq(_.compact(modelNames)));
     });

--- a/bin/generatemodels
+++ b/bin/generatemodels
@@ -27,7 +27,7 @@ if (_.isEmpty(specFiles)) {
 }
 
 const outputDir = config.outputDir || 'dist';
-const outputBaseDir = `${outputDir}/base` || 'dist';
+const outputBaseDir = `${outputDir}/base`;
 const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
 const nameList = [];
 let isV2;

--- a/bin/generatemodels
+++ b/bin/generatemodels
@@ -27,7 +27,7 @@ if (_.isEmpty(specFiles)) {
 }
 
 const outputDir = config.outputDir || 'dist';
-const outputInheritDir = config.outputInheritDir || 'dist';
+const outputBaseDir = `${outputDir}/base` || 'dist';
 const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
 const nameList = [];
 let isV2;
@@ -38,13 +38,13 @@ Promise.all(
   models = _.merge(...models);
   const modelGenerator = new ModelGenerator({
     outputDir,
-    outputInheritDir,
+    outputBaseDir,
     templatePath: config.templates,
     usePropType: config.usePropType,
     useFlow: config.useFlow,
     isV2, attributeConverter,
   });
-  mkdirpPromise(outputInheritDir).then(() => {
+  mkdirpPromise(outputBaseDir).then(() => {
     Promise.all(_.map(models, (model, name) => modelGenerator.writeModel(model, name))).then((modelNames) => {
       modelGenerator.writeIndex(_.uniq(_.compact(modelNames)));
     });

--- a/examples/config/config.models.js
+++ b/examples/config/config.models.js
@@ -4,6 +4,6 @@ function snakeToCamel(str) {
 
 module.exports = {
   outputDir: './tmp/models',
-  outputInheritDir: './tmp/models/inherit',
+  outputInheritDir: './tmp/models/parent',
   attributeConverter: snakeToCamel,
 };

--- a/examples/config/config.models.js
+++ b/examples/config/config.models.js
@@ -4,5 +4,6 @@ function snakeToCamel(str) {
 
 module.exports = {
   outputDir: './tmp/models',
+  outputInheritDir: './tmp/models/inherit',
   attributeConverter: snakeToCamel,
 };

--- a/examples/config/config.models.js
+++ b/examples/config/config.models.js
@@ -4,6 +4,5 @@ function snakeToCamel(str) {
 
 module.exports = {
   outputDir: './tmp/models',
-  outputInheritDir: './tmp/models/parent',
   attributeConverter: snakeToCamel,
 };

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -10,8 +10,9 @@ const {
  */
 
 class ModelGenerator {
-  constructor({outputDir = '', templatePath = {}, specName, isV2, useFlow, usePropType, attributeConverter = str => str}) {
+  constructor({outputDir = '', outputInheritDir = '', templatePath = {}, specName, isV2, useFlow, usePropType, attributeConverter = str => str}) {
     this.outputDir = outputDir;
+    this.outputInheritDir = outputInheritDir;
     this.templatePath = templatePath;
     this.specName = specName;
     this.isV2 = isV2;
@@ -33,7 +34,7 @@ class ModelGenerator {
     if (!idAttribute) return;
 
     const coreText = this._renderBaseModel(name, applyRequired(properties, required), idAttribute);
-    return writeFilePromise(path.join(this.outputDir, `_${fileName}.js`), coreText).then(() => {
+    return writeFilePromise(path.join(this.outputInheritDir, `_${fileName}.js`), coreText).then(() => {
       return this._writeOverrideModel(name, fileName).then(() => name);
     });
   }

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -10,9 +10,9 @@ const {
  */
 
 class ModelGenerator {
-  constructor({outputDir = '', outputInheritDir = '', templatePath = {}, specName, isV2, useFlow, usePropType, attributeConverter = str => str}) {
+  constructor({outputDir = '', outputBaseDir = '', templatePath = {}, specName, isV2, useFlow, usePropType, attributeConverter = str => str}) {
     this.outputDir = outputDir;
-    this.outputInheritDir = outputInheritDir;
+    this.outputBaseDir = outputBaseDir;
     this.templatePath = templatePath;
     this.specName = specName;
     this.isV2 = isV2;
@@ -34,7 +34,7 @@ class ModelGenerator {
     if (!idAttribute) return;
 
     const coreText = this._renderBaseModel(name, applyRequired(properties, required), idAttribute);
-    return writeFilePromise(path.join(this.outputInheritDir, `_${fileName}.js`), coreText).then(() => {
+    return writeFilePromise(path.join(this.outputBaseDir, `${fileName}.js`), coreText).then(() => {
       return this._writeOverrideModel(name, fileName).then(() => name);
     });
   }

--- a/templates/override_template.mustache
+++ b/templates/override_template.mustache
@@ -1,6 +1,6 @@
 {{>head}}
-import _{{name}} from './_{{fileName}}';
-export * from './_{{fileName}}';
+import _{{name}} from './parent/_{{fileName}}';
+export * from './parent/_{{fileName}}';
 
 export default class {{name}} extends _{{name}} {
   /**

--- a/templates/override_template.mustache
+++ b/templates/override_template.mustache
@@ -1,8 +1,8 @@
 {{>head}}
-import _{{name}} from './parent/_{{fileName}}';
-export * from './parent/_{{fileName}}';
+import _{{name}} from './base/{{fileName}}';
+export * from './base/{{fileName}}';
 
-export default class {{name}} extends _{{name}} {
+export default class {{name}} extends {{name}} {
   /**
    * write custom methods here
    */


### PR DESCRIPTION
自動生成されるｍodelsのうち、`_xxx.js` のように頭に'_'がつくものを `parent` というサブディレクトリに出力されるよう改変しました。これにより、tmpのディレクトリ構成は以下のようになります。

```
models
  ├ parent
        ├ _car.js
        ├ _dog.js
        ├ _person.js
        ├ _pet.js
  ├ cat.js
  ├ dog.js
  ├ index.js
  ├ person.js
  ├ pet.js
```