### PR TITLE
arrayの場合のprop-type生成を追加

### DIFF
--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -168,6 +168,12 @@ class ModelGenerator {
       };
     }
 
+    if (prop.type === 'array' && prop.items && prop.items.type) {
+      return {
+        propType: `ImmutablePropTypes.listOf(${_getPropTypes(prop.items.type)})`,
+      };
+    }
+
     if (prop.type === 'object' && prop.properties) {
       const props = _.reduce(prop.properties, (acc, value, key) => {
         acc[this.attributeConverter(key)] = _getPropTypes(value.type, value.enum);


### PR DESCRIPTION
シンプルな `array` に対してprop-type生成が漏れていた。
すぐ下の実装で `object` に対して実施しているように `array` の処理を追加。