### PR TITLE
entities-reducerにinitialStateを渡せるように

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
       // mocha
       "describe": true,
       "it": true,
-      "beforeEach": true
+      "beforeEach": true,
+      "afterEach": true
     },
     "rules": {
         "accessor-pairs": "error",
@@ -204,7 +205,7 @@ module.exports = {
         "no-throw-literal": "error",
         "no-trailing-spaces": "error",
         "no-undef-init": "error",
-        "no-undefined": "error",
+        "no-undefined": "warn",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ createOpenApiMiddleware(Spec).then((middleware) => {
 
 ## API
 
-### createEntitiesReducer(Models, [additionalReducer])
+### createEntitiesReducer(Models, {additionalReducer})
 create reducer that output normalized state as model. (normalized by [normalizr](https://github.com/paularmstrong/normalizr))
 
 #### Models

--- a/dist/entities-reducer.js
+++ b/dist/entities-reducer.js
@@ -13,8 +13,6 @@ function _defineProperties(target, props) { for (var i = 0; i < props.length; i+
 
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
 
-var initialState = (0, _immutable.Map)();
-
 function isOpenApiAction(meta) {
   return meta && meta.openApi;
 }
@@ -28,13 +26,15 @@ var EntitiesReducer =
 function () {
   function EntitiesReducer() {
     var Models = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var additionalReducer = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function (state) {
+    var initialState = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : (0, _immutable.Map)();
+    var additionalReducer = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function (state) {
       return state;
     };
 
     _classCallCheck(this, EntitiesReducer);
 
     this.Models = Models;
+    this.initialState = initialState;
     this.additionalReducer = additionalReducer;
     this.reduce = this.reduce.bind(this);
   }
@@ -42,7 +42,7 @@ function () {
   _createClass(EntitiesReducer, [{
     key: "reduce",
     value: function reduce() {
-      var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : initialState;
+      var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.initialState;
       var action = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var newEntities = getNewEntities(action);
 
@@ -76,7 +76,9 @@ function () {
   return EntitiesReducer;
 }();
 
-function createReducer(Models, additionalReducer) {
-  var reducer = new EntitiesReducer(Models, additionalReducer);
+function createReducer(Models, _ref) {
+  var initialState = _ref.initialState,
+      additionalReducer = _ref.additionalReducer;
+  var reducer = new EntitiesReducer(Models, initialState, additionalReducer);
   return reducer.reduce;
 }

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -38,7 +38,7 @@ const payloadCreator = (payload) => snakeKeys(payload);
 
 createOpenApiMiddleware(rawSpec, httpOption).then((middleware) => {
   const store = createStore(
-    createEntitiesReducer(Models, additionalReducer),
+    createEntitiesReducer(Models, {additionalReducer}),
     applyMiddleware(middleware)
   );
 

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -9,7 +9,7 @@
    * @params additionalReducer Function マージでは対応できない処理を追加する関数
    * @returns Function reducer関数を返します
    */
-  createEntitiesReducer(Models, [additionalReducer])
+  createEntitiesReducer(Models, {additionalReducer})
   ```
 - additionalReducerの例
   ```js

--- a/src/lib/entities-reducer.js
+++ b/src/lib/entities-reducer.js
@@ -1,7 +1,5 @@
 import { Map, fromJS } from 'immutable';
 
-const initialState = Map();
-
 function isOpenApiAction(meta) {
   return meta && meta.openApi;
 }
@@ -11,13 +9,14 @@ function getNewEntities(action) {
 }
 
 class EntitiesReducer {
-  constructor(Models = {}, additionalReducer = (state) => state) {
+  constructor(Models = {}, initialState = Map(), additionalReducer = (state) => state) {
     this.Models = Models;
+    this.initialState = initialState;
     this.additionalReducer = additionalReducer;
     this.reduce = this.reduce.bind(this);
   }
 
-  reduce(state = initialState, action = {}) {
+  reduce(state = this.initialState, action = {}) {
     const newEntities = getNewEntities(action);
     if (newEntities) {
       state = this._mergeEntities(state, newEntities);
@@ -39,7 +38,7 @@ class EntitiesReducer {
   }
 }
 
-export function createReducer(Models, additionalReducer) {
-  const reducer = new EntitiesReducer(Models, additionalReducer);
+export function createReducer(Models, {initialState, additionalReducer}) {
+  const reducer = new EntitiesReducer(Models, initialState, additionalReducer);
   return reducer.reduce;
 }

--- a/src/lib/entities-reducer.test.js
+++ b/src/lib/entities-reducer.test.js
@@ -1,15 +1,26 @@
 import assert from 'assert';
 import { createReducer } from './entities-reducer';
-import { Record, fromJS } from 'immutable';
+import { Map, Record, fromJS } from 'immutable';
 
 class DummyClass extends Record({id: undefined, name: undefined}) {} // eslint-disable-line no-undefined
 const additionalReducer = (state) => state;
 
 describe('createReducer', () => {
-  const subject = () => createReducer({dummy: DummyClass}, additionalReducer);
+  let initialState;
+  const subject = () => createReducer({dummy: DummyClass}, {initialState, additionalReducer});
+
+  afterEach(() => {
+    initialState = undefined;
+  });
 
   it('get reducer function', () => {
     assert(typeof subject() === 'function');
+  });
+
+  it('can send initialState', () => {
+    initialState = Map({foo: 'bar'});
+    const reducer = subject();
+    assert.deepStrictEqual(reducer(), initialState);
   });
 
   it('reducer can reduce entities with openAPI action', () => {


### PR DESCRIPTION
## やりたいこと
- reducerとしてinitalStateを渡せるようにしておきたい

## 変更点
- create関数の第２引数の型をObject形式に変換して `initalState`を渡せるように
- 関連テスト, Readmeを修正