### PR TITLE
enum対応の修正

### DIFF
--- a/examples/petstore.v3.yml
+++ b/examples/petstore.v3.yml
@@ -173,6 +173,9 @@ components:
         - id
         - name
         - object_type
+      x-enum-key-attribute:
+        - Dog
+        - Cat
       properties:
         object_type:
           type: string

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -246,9 +246,11 @@ function getPropTypes() {
 }
 
 function _getPropTypes(type, enums, enumObjects) {
-  if (enums) {
+  if (enumObjects) {
     const nameMap = enumObjects.map((current) => current.name);
     return `PropTypes.oneOf([${nameMap.join(', ')}])`;
+  } else if (enums) {
+    return `PropTypes.oneOf([${enums.join(', ')}])`;
   }
   switch (type) {
     case 'integer':

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -167,7 +167,7 @@ function getIdAttribute(model, name) {
   const {properties} = model;
   if (!properties) {
     if (name) {
-      console.warn(`${name} does not model definition.`); // eslint-disable-line no-console
+      console.warn(`${name} is not model definition.`); // eslint-disable-line no-console
     }
     return false;
   }

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -181,6 +181,12 @@ function getIdAttribute(model, name) {
   return idAttribute;
 }
 
+function getEnumKeysAttribute(model) {
+  if (model['enum']) return false;
+  const enumKeyAttribute = model['x-enum-key-attribute'] ? model['x-enum-key-attribute'] : undefined;
+  return enumKeyAttribute;
+}
+
 function isModelDefinition(model, name) {
   if (model['$ref'] && !model['$$ref']) {
     // cannot check because of no dereferenced
@@ -205,6 +211,7 @@ module.exports = {
   getSchemaDir,
   changeFormat,
   getIdAttribute,
+  getEnumKeysAttribute,
   isModelDefinition,
   parseModelName,
 };


### PR DESCRIPTION
#35 の対応で以下の問題があったため、修正を行った
    - _getPropTypesにenumObjectが引数として指定されていなかった場合にNPEが発生する
        → enum値のみが指定されている場合は、値そのものをoneOfに指定するという従来の実装を追加
    - 定数の命名規則が不適切（末尾に値そのものが付与されていたため、整数値もそのままの形で変換されてしまう）
        → `x-enum-key-attribute` という拡張プロパティにenum値のキーを指定させるように改変