### PR TITLE
x-enum-key-attribute指定なしに対応

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -99,5 +99,5 @@ https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#speci
   ネストしている属性を利用する場合、`xxx.yyy` のような指定もできる。
 - x-attribute-as
   文字列形式で同モデル内での属性エイリアスを定義する。 (非推奨)
-- x-enum-key-attribute  
-  プロパティの中にenumで指定しているものを保持している場合に、そのキーを指定する。(未指定時は `undefined`)
+- x-enum-key-attributes
+  プロパティの中にenumで指定しているものを保持している場合に、そのキーを指定する。

--- a/examples/petstore.v3.yml
+++ b/examples/petstore.v3.yml
@@ -159,15 +159,17 @@ components:
         - $ref: '#/components/schemas/Pet'
         - properties:
             object_type:
-              type: string
-              default: 'Dog'
+              type: integer
+              format: int32
+              default: 1
     Cat:
       allOf:
         - $ref: '#/components/schemas/Pet'
         - properties:
             object_type:
-              type: string
-              default: 'Cat'
+              type: integer
+              format: int32
+              default: 2
     Pet:
       required:
         - id
@@ -175,13 +177,14 @@ components:
         - object_type
       properties:
         object_type:
-          type: string
+          type: integer
+          format: int32
+          x-enum-key-attributes:
+            - Dog
+            - Cat
           enum:
-            - Dog
-            - Cat
-          x-enum-key-attribute:
-            - Dog
-            - Cat
+            - 1
+            - 2
         name:
           type: string
         tag:

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -123,16 +123,6 @@ class ModelGenerator {
     ];
   }
 
-  _prepareEnumKeyAttributes(name, enumKeyAttribute) {
-    if (!enumKeyAttribute) return false;
-    const convertedName = _.upperCase(name).split(' ').join('_');
-    const enumKeyAttributes = enumKeyAttribute.map(key => {
-      const convertedkey = _.upperCase(key).split(' ').join('_');
-      return `${convertedName}_${convertedkey}`;
-    });
-    return enumKeyAttributes;
-  }
-
   _convertPropForTemplate(properties, dependencySchema = {}) {
     return _.map(properties, (prop, name) => {
       const base = {
@@ -143,7 +133,7 @@ class ModelGenerator {
         isEnum: Boolean(prop.enum),
         isValueString: prop.type === 'string',
         propertyName: name,
-        enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum, prop['x-enum-key-attribute']),
+        enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum, prop['x-enum-key-attributes']),
       };
       return this.constructor.templatePropNames.reduce((ret, key) => {
         ret[key] = ret[key] || properties[name][key];
@@ -152,13 +142,18 @@ class ModelGenerator {
     });
   }
 
-  getEnumObjects(name, enums, enumKeyAttribute) {
+  getEnumConstantName(enumName, propertyName) {
+    const convertedName = _.upperCase(propertyName).split(' ').join('_');
+    const convertedkey = _.upperCase(enumName).split(' ').join('_');
+    return `${convertedName}_${convertedkey}`;
+  }
+
+  getEnumObjects(name, enums, enumKeyAttributes = []) {
     if (!enums) return false;
-    const enumKeyAttributes = this._prepareEnumKeyAttributes(name, enumKeyAttribute);
     return enums.map((current, index) => {
-      const enumName = enumKeyAttributes[index];
+      const enumName = enumKeyAttributes[index] || current;
       return {
-        'name': enumName,
+        'name': this.getEnumConstantName(enumName, name),
         'value': current,
       };
     });
@@ -252,15 +247,10 @@ function getPropTypes() {
 
 function _getPropTypes(type, enums, enumObjects) {
   if (enumObjects) {
-    const nameMap = enumObjects.map((current) => {
-      if (!current.name) {
-        console.warn('This object has no "name" property.It will be "undefined".'); // eslint-disable-line no-console
-      }
-      return current.name
-    });
+    const nameMap = enumObjects.map(current => current.name);
     return `PropTypes.oneOf([${nameMap.join(', ')}])`;
   } else if (enums) {
-    return `PropTypes.oneOf([${enums.join(', ')}])`;
+    return `PropTypes.oneOf([${enums.map(n => type === 'string' ? `'${n}'` : n).join(', ')}])`;
   }
   switch (type) {
     case 'integer':


### PR DESCRIPTION
タイトル通り

`x-enum-key-attribute`指定がない(`enumObjects`がない) 場合は、 ~~定数を作らずに `enum`をそのまま使う~~
`enum`の値を使って定数を作る