### PR TITLE
エラー時にprefix付きのactionをdispatchする

### DIFF
--- a/dist/redux-open-api.js
+++ b/dist/redux-open-api.js
@@ -77,7 +77,7 @@ var _default = function _default(spec, httpOptions) {
             return response;
           }, function (error) {
             next({
-              type: action.type,
+              type: "ERROR_".concat(action.type),
               meta: action.meta,
               payload: error,
               error: true

--- a/src/lib/redux-open-api.js
+++ b/src/lib/redux-open-api.js
@@ -52,7 +52,7 @@ export default (spec, httpOptions) => {
         },
         (error) => {
           next({
-            type: action.type,
+            type: `ERROR_${action.type}`,
             meta: action.meta,
             payload: error,
             error: true,

--- a/src/lib/redux-open-api.test.js
+++ b/src/lib/redux-open-api.test.js
@@ -43,7 +43,7 @@ describe('middleware', () => {
       nock(/.*/).get('/pets').reply(400);
     });
     it('call action with error.', () => subject(action).then(noop, () => {
-      sinon.assert.calledWith(nextFunction, sinon.match({error: true}));
+      sinon.assert.calledWith(nextFunction, sinon.match({error: true, type: 'ERROR_GET_PETS'}));
     }));
   });
 });


### PR DESCRIPTION
成功時と失敗時をaction.typeで判断できるように、失敗時にprefix (ERROR) を付ける