### PR TITLE
出力ファイルの指定を個別に

### DIFF
--- a/bin/generatemodels
+++ b/bin/generatemodels
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable dot-location,no-console,no-process-exit,no-unused-vars*/
 /**
  * generate models from multi spec files.
  */
@@ -26,15 +27,13 @@ if (_.isEmpty(specFiles)) {
   process.exit(1);
 }
 
-const outputDir = config.outputDir || 'dist';
+const outputDir = config.modelsDir || 'dist';
 const outputBaseDir = `${outputDir}/base`;
 const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
 const nameList = [];
 let isV2;
 
-Promise.all(
-  specFiles.map((file) => Swagger({spec: readSpecFile(file)}).then(({spec}) => filter(spec)))
-).then((models) => {
+Promise.all(specFiles.map((file) => Swagger({spec: readSpecFile(file)}).then(({spec}) => filter(spec)))).then((models) => {
   models = _.merge(...models);
   const modelGenerator = new ModelGenerator({
     outputDir,

--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable dot-location,no-console,no-process-exit,no-unused-vars*/
 /**
  * generate actionType.js, schema.js, spec.js from multi spec files.
  * - need models directory before execution
@@ -29,14 +30,20 @@ if (_.isEmpty(specFiles)) {
   process.exit(1);
 }
 
+console.log(`
+  output:
+    actionTypes: ${config.outputPath.actions}
+    schemas    : ${config.outputPath.schemas}
+    js-spec    : ${config.outputPath.jsSpec}
+`);
+
 const spec = specFiles.reduce((acc, file) => {
   return _.merge(acc, readSpecFile(file));
 }, {});
 
-const outputDir = config.outputDir || 'dist';
-const [actionsDir, schemasDir] = ['actions', 'schemas'].map((dir) => resolvePath(path.join(outputDir, dir)));
-const prepareDirs = [actionsDir, schemasDir].map((path) => mkdirpPromise(path));
-let modelGenerator, schemaGenerator, actionTypesGenerator;
+let actionTypesGenerator, modelGenerator, schemaGenerator;
+const [actionsDir, schemasDir, specDir] = ['actions', 'schemas', 'jsSpec'].map((key) => path.dirname(config.outputPath[key]));
+const prepareDirs = [actionsDir, schemasDir, specDir].map((p) => mkdirpPromise(p));
 
 const rawSpec = _.cloneDeep(spec);
 
@@ -44,7 +51,11 @@ Swagger({spec}).then(({spec}) => {
   return Promise.all(prepareDirs).then(() => {
     const isV2 = spec.swagger === '2.0';
     const models = isV2 ? spec.definitions : spec.components.schemas;
-    (new JsSpecGenerator({outputDir, templatePath: config.templates, specName: 'spec.yml'})).write(rawSpec);
+    const writePromises = [];
+    writePromises.push((new JsSpecGenerator({
+      templatePath: config.templates,
+      outputPath: config.outputPath.jsSpec,
+    })).write(rawSpec));
 
     const modelNameList = [];
     const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
@@ -62,18 +73,19 @@ Swagger({spec}).then(({spec}) => {
     walkModels(models, [onModel]);
 
     actionTypesGenerator = new ActionTypesGenerator({
-      outputDir: actionsDir,
+      outputPath: config.outputPath.actions,
       templatePath: config.templates,
-      schemasDir,
+      schemasFilePath: config.outputPath.schemas,
     });
     schemaGenerator = new SchemaGenerator({
-      outputDir: schemasDir,
+      outputPath: config.outputPath.schemas,
       templatePath: config.templates,
       modelsDir: config.modelsDir, modelNameList, isV2, attributeConverter,
     });
     walkResponses(spec.paths, [schemaGenerator.parse, actionTypesGenerator.appendId]);
-    schemaGenerator.write();
-    actionTypesGenerator.write();
+    writePromises.push(schemaGenerator.write());
+    writePromises.push(actionTypesGenerator.write());
+    return writePromises;
   });
 }).catch((e) => console.error(`Failed: ${e}`));
 

--- a/config/parser-config-default.js
+++ b/config/parser-config-default.js
@@ -10,13 +10,18 @@ const templates = {
   spec: 'templates/spec_template.mustache',
   oneOf: 'templates/one_of_template.mustache',
 };
+const outputPath = {
+  schemas: './tmp/schemas/sample_schema.js',
+  actions: './tmp/action_types/sample.js',
+  jsSpec: './tmp/sample_api.js',
+};
 module.exports = {
   templates: Object.keys(templates).reduce((acc, key) => {
     acc[key] = path.join(__dirname, '../', templates[key]);
     return acc;
   }, {}),
-  modelsDir: 'tmp',
-  outputDir: 'tmp',
+  modelsDir: './tmp',
+  outputPath,
   useFlow: false,
   usePropType: true,
 };

--- a/examples/config/config.models.js
+++ b/examples/config/config.models.js
@@ -3,6 +3,6 @@ function snakeToCamel(str) {
 }
 
 module.exports = {
-  outputDir: './tmp/models',
+  modelsDir: './tmp/models',
   attributeConverter: snakeToCamel,
 };

--- a/examples/config/config.schemas.js
+++ b/examples/config/config.schemas.js
@@ -3,7 +3,11 @@ function snakeToCamel(str) {
 }
 
 module.exports = {
-  outputDir: './tmp',
+  outputPath: {
+    schemas: './tmp/schemas/sample_schema.js',
+    actions: './tmp/action_types/sample.js',
+    jsSpec: './tmp/sample_api.js',
+  },
   modelsDir: './tmp/models',
   attributeConverter: snakeToCamel,
 };

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -5,9 +5,9 @@ import { beforeSend, camelKeys, snakeKeys } from './helper';
 
 
 // 自動生成ファイル
-import rawSpec from '../../tmp/spec';
+import rawSpec from '../../tmp/sample_api';
 import * as Models from '../../tmp/models';
-import * as ActionTypes from '../../tmp/actions/actionTypes';
+import * as ActionTypes from '../../tmp/action_types/sample';
 const createEntitiesAction = ActionTypes.createAction;
 
 import { applyMiddleware, createStore } from 'redux';

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "build:sample": "webpack --config examples/webpack.config.babel.js --progress",
     "build:sample:models": "./bin/generatemodels --config examples/config/config.models.js",
     "build:sample:schemas": "./bin/generateschemas --config examples/config/config.schemas.js",
-    "eslint": "eslint src",
+    "eslint": "eslint src bin",
     "mocha": "NODE_ENV=test mocha --require babel-register ",
     "mock": "swagger project start examples/petstore",
     "prepare:mock": "cd examples/petstore && npm i",

--- a/src/lib/entities-reducer.test.js
+++ b/src/lib/entities-reducer.test.js
@@ -10,7 +10,7 @@ describe('createReducer', () => {
   const subject = () => createReducer({dummy: DummyClass}, {initialState, additionalReducer});
 
   afterEach(() => {
-    initialState = undefined;
+    initialState = undefined; // eslint-disable-line no-undefined
   });
 
   it('get reducer function', () => {

--- a/src/tools/action_types_generator.js
+++ b/src/tools/action_types_generator.js
@@ -2,11 +2,13 @@ const path = require('path');
 const { writeFilePromise, readTemplates, render } = require('./utils');
 
 class ActionTypesGenerator {
-  constructor({outputDir = '', schemasDir, templatePath = {}, operationIdList = [], specName}) {
-    this.outputDir = outputDir;
-    this.schemasDir = schemasDir;
+  constructor({outputPath = '', schemasFilePath = '', templatePath = {}, operationIdList = []}) {
+    this.outputPath = outputPath;
+    const {dir, name, ext} = path.parse(this.outputPath);
+    this.outputDir = dir;
+    this.outputFileName = `${name}${ext}`;
+    this.schemasFilePath = schemasFilePath;
     this.templatePath = templatePath;
-    this.specName = specName;
     this.operationIdList = operationIdList;
     this.templates = readTemplates(['head', 'actionTypes'], this.templatePath);
     this.appendId = this.appendId.bind(this);
@@ -22,12 +24,11 @@ class ActionTypesGenerator {
   write() {
     const text = render(this.templates.actionTypes, {
       operationIdList: this.operationIdList,
-      schemasDir: path.relative(this.outputDir, this.schemasDir),
-      specName: this.specName,
+      schemasFile: path.relative(this.outputDir, this.schemasFilePath).replace(/\.\w+$/, ''),
     }, {
       head: this.templates.head,
     });
-    return writeFilePromise(path.join(this.outputDir, 'actionTypes.js'), text);
+    return writeFilePromise(path.join(this.outputDir, this.outputFileName), text);
   }
 }
 

--- a/src/tools/js_spec_generator.js
+++ b/src/tools/js_spec_generator.js
@@ -2,22 +2,23 @@ const path = require('path');
 const { writeFilePromise, readTemplates, render } = require('./utils');
 
 class JsSpecGenerator {
-  constructor({outputDir = '', templatePath, spec, specName}) {
-    this.outputDir = outputDir;
-    this.templatePath = templatePath;
+  constructor({outputPath = '', templatePath, spec}) {
+    this.outputPath = outputPath;
     this.spec = spec;
-    this.specName = specName;
+    this.templatePath = templatePath;
     this.templates = readTemplates(['spec', 'head'], this.templatePath);
+    const {dir, name, ext} = path.parse(this.outputPath);
+    this.outputDir = dir;
+    this.outputFileName = `${name}${ext}`;
   }
 
   write(spec = this.spec) {
     const text = render(this.templates.spec, {
       spec: JSON.stringify(spec, null, 2),
-      specName: this.specName,
     }, {
       head: this.templates.head,
     });
-    return writeFilePromise(path.join(this.outputDir, this.specName.replace(/\.ya*ml$/, '.js')), text);
+    return writeFilePromise(path.join(this.outputDir, this.outputFileName), text);
   }
 }
 

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -10,11 +10,10 @@ const {
  */
 
 class ModelGenerator {
-  constructor({outputDir = '', outputBaseDir = '', templatePath = {}, specName, isV2, useFlow, usePropType, attributeConverter = str => str}) {
+  constructor({outputDir = '', outputBaseDir = '', templatePath = {}, isV2, useFlow, usePropType, attributeConverter = str => str}) {
     this.outputDir = outputDir;
     this.outputBaseDir = outputBaseDir;
     this.templatePath = templatePath;
-    this.specName = specName;
     this.isV2 = isV2;
     this.useFlow = useFlow;
     this.usePropType = usePropType;
@@ -42,7 +41,6 @@ class ModelGenerator {
   writeIndex(modelNameList) {
     const text = render(this.templates.models, {
       models: _.uniq(modelNameList).map((name) => ({fileName: _.snakeCase(name), name})),
-      specName: this.specName,
     }, {
       head: this.templates.head,
     });
@@ -99,7 +97,6 @@ class ModelGenerator {
       usePropTypes: this.usePropType,
       useFlow: this.useFlow,
       props: this._convertPropForTemplate(properties, dependencySchema),
-      specName: this.specName,
       schema: objectToTemplateValue(changeFormat(dependencySchema, this.attributeConverter)),
       oneOfs: oneOfs.map((obj) => Object.assign(obj, {mapping: objectToTemplateValue(obj.mapping), propertyName: this._prepareIdAttribute(obj.propertyName)})),
       importList: this._prepareImportList(importList),
@@ -234,7 +231,6 @@ class ModelGenerator {
     return render(this.templates.override, {
       name, fileName, enums,
       usePropTypes: this.usePropType,
-      specName: this.specName,
     }, {
       head: this.templates.head,
     });

--- a/src/tools/schema_generator.js
+++ b/src/tools/schema_generator.js
@@ -11,13 +11,15 @@ const {
  */
 
 class SchemaGenerator {
-  constructor({outputDir = '', templatePath = {}, modelNameList = [], modelsDir, isV2, specName, attributeConverter = str => str}) {
-    this.outputDir = outputDir;
+  constructor({outputPath = '', templatePath = {}, modelNameList = [], modelsDir, isV2, attributeConverter = str => str}) {
+    this.outputPath = outputPath;
+    const {dir, name, ext} = path.parse(this.outputPath);
+    this.outputDir = dir;
+    this.outputFileName = `${name}${ext}`;
     this.templatePath = templatePath;
     this.modelNameList = modelNameList; // 利用できるモデル一覧
     this.modelsDir = modelsDir;
     this.isV2 = isV2;
-    this.specName = specName;
     this.attributeConverter = attributeConverter;
     this.templates = readTemplates(['schema', 'head', 'oneOf'], this.templatePath);
     this.parsedObjects = {};
@@ -69,14 +71,13 @@ class SchemaGenerator {
     const text = render(this.templates.schema, {
       importList: this._prepareImportList(),
       data: objectToTemplateValue(this.formattedSchema),
-      specName: this.specName,
       hasOneOf: oneOfs.length > 0,
       oneOfs,
     }, {
       head: this.templates.head,
       oneOf: this.templates.oneOf,
     });
-    return writeFilePromise(path.join(this.outputDir, 'schema.js'), text);
+    return writeFilePromise(path.join(this.outputDir, this.outputFileName), text);
   }
 
   _prepareImportList() {

--- a/templates/action_types_template.mustache
+++ b/templates/action_types_template.mustache
@@ -1,7 +1,7 @@
 {{>head}}
 import isFunction from 'lodash/isFunction';
 import { createAction as _createAction } from 'redux-actions';
-import schemas from '{{&schemasDir}}/schema';
+import schemas from '{{&schemasFile}}';
 {{#operationIdList}}
 export const {{.}} = '{{.}}';
 {{/operationIdList}}

--- a/templates/head_template.mustache
+++ b/templates/head_template.mustache
@@ -1,8 +1,5 @@
 /* eslint-disable */
 /**
- * generated from API definition file {{#specName}}({{specName}}){{/specName}}
-{{#date}}
- * at {{date}}
-{{/date}}
+ * generated from API definition file
  */
 


### PR DESCRIPTION
## 概要
これまでは出力ファイルをディレクトリで指定していた。(それぞれのファイルは内部で固定パス)
それぞれのファイルごとにパスを指定できるようにしたい。

## やったこと
- configに`outputPath` オブジェクトを指定して、ファイルごとにパスを指定できるようにした。
  ```js
  module.exports = {
    outputPath: {
      schemas: './tmp/schemas/sample_schema.js',
      actions: './tmp/action_types/sample.js',
      jsSpec: './tmp/sample_api.js',
    },
    modelsDir: './tmp/models',
  };
  ```
- ついでに使われてない `specName` も削除