### PR TITLE
createAction → createOpenApiActionに名称変更

### DIFF
--- a/templates/action_types_template.mustache
+++ b/templates/action_types_template.mustache
@@ -6,7 +6,7 @@ import schemas from '{{&schemasFile}}';
 export const {{.}} = '{{.}}';
 {{/operationIdList}}
 
-export function createAction(id, payloadCreator = (params) => params, metaCreator) {
+export function createOpenApiAction(id, payloadCreator = (params) => params, metaCreator) {
   const meta = {openApi: true, id: id.toLowerCase(), schema: schemas[id.toLowerCase()]};
   let _metaCreator = () => meta;
   if (isFunction(metaCreator)) {

--- a/templates/action_types_template.mustache
+++ b/templates/action_types_template.mustache
@@ -1,6 +1,6 @@
 {{>head}}
 import isFunction from 'lodash/isFunction';
-import { createAction as _createAction } from 'redux-actions';
+import { createAction } from 'redux-actions';
 import schemas from '{{&schemasFile}}';
 {{#operationIdList}}
 export const {{.}} = '{{.}}';
@@ -12,5 +12,5 @@ export function createOpenApiAction(id, payloadCreator = (params) => params, met
   if (isFunction(metaCreator)) {
     _metaCreator = (...args) => Object.assign(metaCreator(...args), meta);
   }
-  return _createAction(id, payloadCreator, _metaCreator);
+  return createAction(id, payloadCreator, _metaCreator);
 }


### PR DESCRIPTION
`createAction`はopenAPIを使わない場合に、自動生成経由の場合は `createOpenApiAction` を使うものとする。