### PR TITLE
名称変更のexampleの対応

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,7 +54,7 @@
       import rawSpec from 'tmp/spec';
       import * as Models from 'tmp/models';
       import * as ActionTypes from 'tmp/actions/actionTypes';
-      const createEntitiesAction = ActionTypes.createAction;
+      const createEntitiesAction = ActionTypes.createOpenApiAction;
       import { createEntitiesReducer, createOpenApiMiddleware } from 'openapi-to-normalizr';
 
       // JS形式のSpecを渡してAPI通信を自動で行なうmiddlewareを準備する

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -8,7 +8,7 @@ import { beforeSend, camelKeys, snakeKeys } from './helper';
 import rawSpec from '../../tmp/sample_api';
 import * as Models from '../../tmp/models';
 import * as ActionTypes from '../../tmp/action_types/sample';
-const createEntitiesAction = ActionTypes.createAction;
+const createEntitiesAction = ActionTypes.createOpenApiAction;
 
 import { applyMiddleware, createStore } from 'redux';
 import createOpenApiMiddleware from '../../src/lib/redux-open-api';

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -54,10 +54,10 @@
 - このmiddlewareはAPI定義に従った通信結果をnormalizeする責務を持ちます。(immutable.jsのインスタンスは入り込みません)
 
 
-## createAction
-- 自動生成される `actionTypes.js`から `export`される関数です。  
+## createOpenApiAction
+- 自動生成される `action_types/sample.js`から `export`される関数です。  
   I/Fは [redux-actions](https://www.gitbook.com/book/vinnymac/redux-actions)の `createAction` と同様です。
   ```js
-  import { createAction, GET_PETS__ID_ } from 'actions/actionTypes';
-  const action = createAction(GET_PETS__ID_);
+  import { createOpenApiAction, GET_PETS__ID_ } from 'action_types/sample';
+  const action = createOpenApiAction(GET_PETS__ID_);
   ```


### PR DESCRIPTION
以下の対応が入り、自動生成されるaction creatorの名称が変更になったため、ドキュメントとサンプルを修正する。
https://github.com/eightcard/openapi-to-normalizr/pull/51