### PR TITLE
falsyなdefault値をただしく設定する

### DIFF
--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -301,7 +301,7 @@ function _getFlowTypes(type, enums) {
 }
 
 function getDefaults() {
-  if (!this.default) { return 'undefined'; }
+  if (_.isUndefined(this.default)) { return 'undefined'; }
   if (this.enumObjects) {
     for (const enumObject of this.enumObjects) {
       if (enumObject.value === this.default) return enumObject.name;


### PR DESCRIPTION
`default` の評価を真偽値ではなく `_.isUndefined` に変更
以下がきちんと `default` 値として評価される
- 空文字
- 0