### PR TITLE
oneOf指定時のコード生成処理修正

### DIFF
--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -57,7 +57,7 @@ function parseSchema(schema, onSchema, isV2) {
   if (ref && ref.match(schemasDir) && isModelDefinition(schema)) {
     const model = parseModelName(ref, isV2);
     return onSchema({type: 'model', value: model});
-  } else if (schema.oneOf) {
+  } else if (schema.oneOf && schema.discriminator) {
     return onSchema({type: 'oneOf', value: parseOneOf(schema, onSchema, isV2)});
   } else if (schema.type === 'object') {
     return applyIf(parseSchema(schema.properties, onSchema, isV2));


### PR DESCRIPTION
## 問題
oneOf指定時に `discriminator` によるマッピングと、モデル定義を期待した処理になっていた。

## 対応
- `discriminator` がない場合はunion処理できないため、スキーマを作成しないように修正
- oneOf対象がモデルではない場合も考慮して型情報を生成するように修正