### PR TITLE
HttpClientをexportする

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,9 +3,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = exports.resetMetaCreator = exports.createEntitiesReducer = exports.createOpenApiMiddleware = exports.normalizr = exports.immutable = void 0;
+exports.default = exports.HttpClient = exports.resetMetaCreator = exports.createEntitiesReducer = exports.createOpenApiMiddleware = exports.normalizr = exports.immutable = void 0;
 
-var _reduxOpenApi = _interopRequireDefault(require("./redux-open-api"));
+var _reduxOpenApi = _interopRequireWildcard(require("./redux-open-api"));
 
 var _entitiesReducer = require("./entities-reducer");
 
@@ -14,8 +14,6 @@ var _immutable = _interopRequireWildcard(require("immutable"));
 var _normalizr = _interopRequireWildcard(require("normalizr"));
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var immutable = _immutable;
 exports.immutable = immutable;
@@ -27,10 +25,13 @@ var createEntitiesReducer = _entitiesReducer.createReducer;
 exports.createEntitiesReducer = createEntitiesReducer;
 var resetMetaCreator = _entitiesReducer.resetMetaCreator;
 exports.resetMetaCreator = resetMetaCreator;
+var HttpClient = _reduxOpenApi.HttpClient;
+exports.HttpClient = HttpClient;
 var _default = {
   createEntitiesReducer: createEntitiesReducer,
   createOpenApiMiddleware: createOpenApiMiddleware,
   immutable: immutable,
-  normalizr: normalizr
+  normalizr: normalizr,
+  HttpClient: HttpClient
 };
 exports.default = _default;

--- a/dist/redux-open-api.js
+++ b/dist/redux-open-api.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports.default = exports.HttpClient = void 0;
 
 var _swaggerClient = _interopRequireDefault(require("swagger-client"));
 
@@ -20,6 +20,9 @@ function getRequestBody(id, payload) {
 function isOpenApiAction(action) {
   return action && action.meta && action.meta.openApi;
 }
+
+var HttpClient = _swaggerClient.default.http;
+exports.HttpClient = HttpClient;
 
 var _default = function _default(spec, httpOptions) {
   return (0, _swaggerClient.default)({

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import createMiddleware from './redux-open-api';
+import createMiddleware, { HttpClient as _HttpClient } from './redux-open-api';
 import { createReducer, resetMetaCreator as _resetMetaCreator } from './entities-reducer';
 
 import * as _immutable from 'immutable';
@@ -8,9 +8,11 @@ export const normalizr = _normalizr;
 export const createOpenApiMiddleware = createMiddleware;
 export const createEntitiesReducer = createReducer;
 export const resetMetaCreator = _resetMetaCreator;
+export const HttpClient = _HttpClient;
 
 export default {
   createEntitiesReducer,
   createOpenApiMiddleware,
   immutable, normalizr,
+  HttpClient,
 };

--- a/src/lib/redux-open-api.js
+++ b/src/lib/redux-open-api.js
@@ -11,6 +11,8 @@ function isOpenApiAction(action) {
   return action && action.meta && action.meta.openApi;
 }
 
+export const HttpClient = Swagger.http;
+
 export default (spec, httpOptions) => {
   return Swagger({spec}).then(({apis}) => {
     const apiCache = {};

--- a/src/lib/redux-open-api.test.js
+++ b/src/lib/redux-open-api.test.js
@@ -1,8 +1,9 @@
 import nock from 'nock';
 import sinon from 'sinon';
-import createMiddleware from './redux-open-api';
+import createMiddleware, { HttpClient } from './redux-open-api';
 import spec from '../../examples/petstore.v3';
 import noop from 'lodash/noop';
+import assert from 'assert';
 nock.disableNetConnect();
 
 describe('middleware', () => {
@@ -55,5 +56,21 @@ describe('middleware', () => {
     it('call action with error.', () => subject(action).then(noop, () => {
       sinon.assert.calledWith(nextFunction, sinon.match({error: true, type: 'ERROR_GET_PETS'}));
     }));
+  });
+});
+
+describe('http client', () => {
+  const res = {response: 'test response'};
+  beforeEach(() => {
+    nock(/.*/).get('/pets').reply(200, res);
+  });
+
+  it('can request', () => {
+    return HttpClient({
+      url: 'http://localhost/pets',
+    }).then((res) => {
+      assert(res.status, 200);
+      assert(res.body, res);
+    });
   });
 });


### PR DESCRIPTION
汎用的に利用できるクライアントとしてSwagger.httpをexportしておく