### PR TITLE
生成されたコードがeslintに引っかかってしまうので対応

### DIFF
--- a/templates/action_types_template.mustache
+++ b/templates/action_types_template.mustache
@@ -8,7 +8,7 @@ export const {{.}} = '{{.}}';
 {{/operationIdList}}
 
 export function createOpenApiAction(id, payloadCreator = (params) => params, metaCreator) {
-  const meta = {openApi: true, id: id.toLowerCase(), schema: schemas[id.toLowerCase()]};
+  const meta = { openApi: true, id: id.toLowerCase(), schema: schemas[id.toLowerCase()] };
   let _metaCreator = () => meta;
   if (isFunction(metaCreator)) {
     _metaCreator = (...args) => Object.assign(metaCreator(...args), meta);


### PR DESCRIPTION
生成されるaction_typesファイルがeslintで引っかかるためテンプレートファイルを修正しました。