### PR TITLE
Add dereference parse

### DIFF
--- a/bin/generatemodels
+++ b/bin/generatemodels
@@ -9,7 +9,7 @@ const Swagger = require('swagger-client');
 const _ = require('lodash');
 
 const ModelGenerator = require('../src/tools/model_generator');
-const { resolvePath, mkdirpPromise, readSpecFile } = require('../src/tools/utils');
+const { resolvePath, mkdirpPromise, readSpecFilePromise } = require('../src/tools/utils');
 
 program
   .option('-c, --config <configPath>', 'config path')
@@ -33,7 +33,7 @@ const attributeConverter = config.attributeConverter ? config.attributeConverter
 const nameList = [];
 let isV2;
 
-Promise.all(specFiles.map((file) => Swagger({spec: readSpecFile(file)}).then(({spec}) => filter(spec)))).then((models) => {
+Promise.all(specFiles.map((file) => readSpecFilePromise(file, {dereference: true}).then((schema) => Swagger({ spec: schema })).then(({ spec }) => filter(spec)))).then((models) => {
   models = _.merge(...models);
   const modelGenerator = new ModelGenerator({
     outputDir,

--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -8,7 +8,7 @@ const path = require('path');
 const Swagger = require('swagger-client');
 const program = require('commander');
 const _ = require('lodash');
-const { resolvePath, mkdirpPromise, readSpecFile, isModelDefinition } = require('../src/tools/utils');
+const { resolvePath, mkdirpPromise, readSpecFilePromise, isModelDefinition } = require('../src/tools/utils');
 const ModelGenerator = require('../src/tools/model_generator');
 const SchemaGenerator = require('../src/tools/schema_generator');
 const ActionTypesGenerator = require('../src/tools/action_types_generator');
@@ -37,59 +37,61 @@ console.log(`
     js-spec    : ${config.outputPath.jsSpec}
 `);
 
-const spec = specFiles.reduce((acc, file) => {
-  return _.merge(acc, readSpecFile(file));
-}, {});
+Promise.all(specFiles.map((file) => readSpecFilePromise(file, {dereference: true}))).then((schemas) => {
+  const spec = _.merge(...schemas);
 
-let actionTypesGenerator, modelGenerator, schemaGenerator;
-const [actionsDir, schemasDir, specDir] = ['actions', 'schemas', 'jsSpec'].map((key) => path.dirname(config.outputPath[key]));
-const prepareDirs = [actionsDir, schemasDir, specDir].map((p) => mkdirpPromise(p));
+  let actionTypesGenerator, modelGenerator, schemaGenerator;
+  const [actionsDir, schemasDir, specDir] = ['actions', 'schemas', 'jsSpec'].map((key) => path.dirname(config.outputPath[key]));
+  const prepareDirs = [actionsDir, schemasDir, specDir].map((p) => mkdirpPromise(p));
 
-const rawSpec = _.cloneDeep(spec);
+  return Swagger({spec}).then(({spec}) => {
+    return Promise.all(prepareDirs).then(() => {
+      const isV2 = spec.swagger === '2.0';
+      const models = isV2 ? spec.definitions : spec.components.schemas;
+      const writePromises = [];
+      const modelNameList = [];
+      const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
+      modelGenerator = new ModelGenerator({
+        templatePath: config.templates,
+        usePropType: config.usePropType,
+        useFlow: config.useFlow,
+        isV2, attributeConverter,
+      });
+      const onModel = (model, name) => {
+        if (isModelDefinition(model, name) && !modelNameList.includes(name)) {
+          modelNameList.push(name);
+        }
+      };
+      walkModels(models, [onModel]);
 
-Swagger({spec}).then(({spec}) => {
-  return Promise.all(prepareDirs).then(() => {
-    const isV2 = spec.swagger === '2.0';
-    const models = isV2 ? spec.definitions : spec.components.schemas;
-    const writePromises = [];
-    writePromises.push((new JsSpecGenerator({
+      actionTypesGenerator = new ActionTypesGenerator({
+        outputPath: config.outputPath.actions,
+        templatePath: config.templates,
+        schemasFilePath: config.outputPath.schemas,
+      });
+      schemaGenerator = new SchemaGenerator({
+        outputPath: config.outputPath.schemas,
+        templatePath: config.templates,
+        modelsDir: config.modelsDir, modelNameList, isV2, attributeConverter,
+      });
+      walkResponses(spec.paths, [schemaGenerator.parse, actionTypesGenerator.appendId]);
+      writePromises.push(schemaGenerator.write());
+      writePromises.push(actionTypesGenerator.write());
+      return writePromises;
+    });
+  }).catch((e) => {
+    console.error(`Failed: ${e}`);
+    process.exit(1);
+  });
+}).then(() => {
+  // no need dereference for js spec file
+  return Promise.all(specFiles.map((file) => readSpecFilePromise(file, { dereference: false }))).then((schemas) => {
+    const spec = _.merge(...schemas);
+    return (new JsSpecGenerator({
       templatePath: config.templates,
       outputPath: config.outputPath.jsSpec,
-    })).write(rawSpec));
-
-    const modelNameList = [];
-    const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;
-    modelGenerator = new ModelGenerator({
-      templatePath: config.templates,
-      usePropType: config.usePropType,
-      useFlow: config.useFlow,
-      isV2, attributeConverter,
-    });
-    const onModel = (model, name) => {
-      if (isModelDefinition(model, name) && !modelNameList.includes(name)) {
-        modelNameList.push(name);
-      }
-    };
-    walkModels(models, [onModel]);
-
-    actionTypesGenerator = new ActionTypesGenerator({
-      outputPath: config.outputPath.actions,
-      templatePath: config.templates,
-      schemasFilePath: config.outputPath.schemas,
-    });
-    schemaGenerator = new SchemaGenerator({
-      outputPath: config.outputPath.schemas,
-      templatePath: config.templates,
-      modelsDir: config.modelsDir, modelNameList, isV2, attributeConverter,
-    });
-    walkResponses(spec.paths, [schemaGenerator.parse, actionTypesGenerator.appendId]);
-    writePromises.push(schemaGenerator.write());
-    writePromises.push(actionTypesGenerator.write());
-    return writePromises;
+    })).write(spec);
   });
-}).catch((e) => {
-  console.error(`Failed: ${e}`);
-  process.exit(1);
 });
 
 function walkModels(models, onModels = []) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "commander": "2.20.0",
     "js-yaml": "3.13.1",
+    "json-schema-ref-parser": "6.1.0",
     "lodash": "4.17.11",
     "mkdirp": "0.5.1",
     "mustache": "3.0.1",

--- a/spec/__snapshots__/generatemodels.test.js.snap
+++ b/spec/__snapshots__/generatemodels.test.js.snap
@@ -12,6 +12,48 @@ import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 
+export const GENDER_MALE: string = 'male';
+export const GENDER_FEMALE: string = 'female';
+export const GENDER_OTHER: string = 'other';
+
+const defaultValues = {
+  name: undefined,
+  gender: undefined,
+};
+
+export const schema = new _schema.Entity('Owner', {}, {idAttribute: 'name'});
+
+
+/**
+ * @params ids : Owner's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Owner extends Record(defaultValues) {
+  name: string;
+  gender: string;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/owner.js",
+}
+`;
+
+exports[`model generator spec from json schema ref 2`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+
 export const KIND_DOG: string = 'Dog';
 export const KIND_CAT: string = 'Cat';
 
@@ -41,7 +83,7 @@ export default class Pet extends Record(defaultValues) {
 }
 `;
 
-exports[`model generator spec from json schema ref 2`] = `
+exports[`model generator spec from json schema ref 3`] = `
 Object {
   "output": "/* eslint-disable */
 // @flow
@@ -52,7 +94,7 @@ Object {
 import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
-import Pet&#x2F;properties&#x2F;id, { schema as Pet&#x2F;properties&#x2F;idSchema } from './pet_properties_id';
+import Owner, { schema as OwnerSchema } from './owner';
 
 export const KIND_DOG: string = 'Dog';
 export const KIND_CAT: string = 'Cat';
@@ -66,7 +108,7 @@ const defaultValues = {
 
 export const schema = new _schema.Entity('WrappedPet', {}, {idAttribute: 'id'});
 schema.define({
-  id: Pet&#x2F;properties&#x2F;idSchema
+  owner: OwnerSchema
 });
 
 
@@ -77,10 +119,10 @@ schema.define({
 export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
 
 export default class WrappedPet extends Record(defaultValues) {
-  id: Pet/properties/id;
+  id: number;
   name: string;
   kind: string;
-  owner: any;
+  owner: Owner;
   static denormalize(id: number[] | string[], entities: any) {
     return denormalize(id, entities);
   }
@@ -90,7 +132,7 @@ export default class WrappedPet extends Record(defaultValues) {
 }
 `;
 
-exports[`model generator spec from json schema ref 3`] = `
+exports[`model generator spec from json schema ref 4`] = `
 Object {
   "output": "/**
  * generated from API definition file
@@ -98,17 +140,40 @@ Object {
 
 import WrappedPet from './wrapped_pet';
 import Pet from './pet';
+import Owner from './owner';
 
 export {
   WrappedPet,
   Pet,
+  Owner,
 };
 ",
   "path": "tmp/index.js",
 }
 `;
 
-exports[`model generator spec from json schema ref 4`] = `
+exports[`model generator spec from json schema ref 5`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Owner from './base/owner';
+export * from './base/owner';
+
+export default class Owner extends _Owner {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/owner.js",
+}
+`;
+
+exports[`model generator spec from json schema ref 6`] = `
 Object {
   "output": "/* eslint-disable comma-dangle */
 /**
@@ -129,7 +194,7 @@ export default class Pet extends _Pet {
 }
 `;
 
-exports[`model generator spec from json schema ref 5`] = `
+exports[`model generator spec from json schema ref 7`] = `
 Object {
   "output": "/* eslint-disable comma-dangle */
 /**

--- a/spec/json_schema_ref.yml
+++ b/spec/json_schema_ref.yml
@@ -64,6 +64,7 @@ components:
             - Cat
     Owner:
       type: object
+      x-id-attribute: name
       properties:
         name:
           description: owner's name

--- a/src/tools/utils.js
+++ b/src/tools/utils.js
@@ -55,7 +55,8 @@ function parseSchema(schema, onSchema, isV2) {
   if (!_.isObject(schema)) return;
 
   const ref = schema['$$ref'] || schema['$ref']; // $$ref is resolved reference.
-  if (ref && ref.match(schemasDir) && isModelDefinition(schema)) {
+  const matcher = new RegExp(`${schemasDir}[^/]*$`); // allow only model name
+  if (ref && ref.match(matcher) && isModelDefinition(schema)) {
     const model = parseModelName(ref, isV2);
     return onSchema({type: 'model', value: model});
   } else if (schema.oneOf && schema.discriminator) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,6 +1722,11 @@ call-matcher@^1.0.0:
     espurify "^1.6.0"
     estraverse "^4.0.0"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
+
 call-signature@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/call-signature/-/call-signature-0.0.2.tgz#a84abc825a55ef4cb2b028bd74e205a65b9a4996"
@@ -3010,6 +3015,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+format-util@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.3.tgz#032dca4a116262a12c43f4c3ec8566416c5b2d95"
+  integrity sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -4180,7 +4190,7 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.13.1, js-yaml@^3.12.0, js-yaml@^3.13.0:
+js-yaml@3.13.1, js-yaml@^3.12.0, js-yaml@^3.12.1, js-yaml@^3.13.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4239,6 +4249,15 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+json-schema-ref-parser@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
+  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.12.1"
+    ono "^4.0.11"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -5012,6 +5031,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+ono@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
+  integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
+  dependencies:
+    format-util "^1.0.3"
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
## やりたいこと
https://github.com/eightcard/openapi-to-normalizr/issues/225
スキーマ定義がpropertiesなどに及ばないようにしたい (refによる連携はモデルに限定したい)

## やったこと
- モデル定義かの判定条件を修正 https://github.com/eightcard/openapi-to-normalizr/commit/f721e5fee0e4dafcaeb3683cbdc109398e655b4f
- モデル定義ではない場合にその先の情報が欠如してしまうので、あらかじめ ref を解決できるように https://github.com/eightcard/openapi-to-normalizr/commit/0d382d085fee2bc812398c11d109c031a7cc62af
- JS用のSpec生成では上記 dereference は不要なため、コマンド内で処理を分離
