### PR TITLE
array内でのoneOf処理を修正

### DIFF
--- a/spec/__snapshots__/generatemodels.test.js.snap
+++ b/spec/__snapshots__/generatemodels.test.js.snap
@@ -214,3 +214,291 @@ export default class WrappedPet extends _WrappedPet {
   "path": "tmp/wrapped_pet.js",
 }
 `;
+
+exports[`model generator spec parse oneOf type 1`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+import Dog, { schema as DogSchema } from './dog';
+import Cat, { schema as CatSchema } from './cat';
+
+
+const defaultValues = {
+  name: undefined,
+  pets: undefined,
+};
+
+export const schema = new _schema.Entity('Breeder', {}, {idAttribute: 'name'});
+const oneOfSchema1 = new _schema.Union({
+  dog: DogSchema,
+  cat: CatSchema
+}, 'kind');
+schema.define({
+  pets: [
+    oneOfSchema1
+  ]
+});
+
+
+/**
+ * @params ids : Breeder's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Breeder extends Record(defaultValues) {
+  name: string;
+  pets: (Dog | Cat)[];
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/breeder.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 2`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+
+export const KIND_CAT: string = 'cat';
+
+const defaultValues = {
+  id: undefined,
+  kind: undefined,
+  name: undefined,
+};
+
+export const schema = new _schema.Entity('Cat', {}, {idAttribute: 'id'});
+
+
+/**
+ * @params ids : Cat's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Cat extends Record(defaultValues) {
+  id: number;
+  kind: string;
+  name: string;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/cat.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 3`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+
+export const KIND_DOG: string = 'dog';
+
+const defaultValues = {
+  id: undefined,
+  kind: undefined,
+  name: undefined,
+};
+
+export const schema = new _schema.Entity('Dog', {}, {idAttribute: 'id'});
+
+
+/**
+ * @params ids : Dog's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Dog extends Record(defaultValues) {
+  id: number;
+  kind: string;
+  name: string;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/dog.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 4`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+import Dog, { schema as DogSchema } from './dog';
+import Cat, { schema as CatSchema } from './cat';
+
+
+const defaultValues = {
+  name: undefined,
+  pet: undefined,
+};
+
+export const schema = new _schema.Entity('Owner', {}, {idAttribute: 'name'});
+const oneOfSchema1 = new _schema.Union({
+  dog: DogSchema,
+  cat: CatSchema
+}, 'kind');
+schema.define({
+  pet: oneOfSchema1
+});
+
+
+/**
+ * @params ids : Owner's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Owner extends Record(defaultValues) {
+  name: string;
+  pet: Dog | Cat;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/owner.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 5`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Breeder from './base/breeder';
+export * from './base/breeder';
+
+export default class Breeder extends _Breeder {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/breeder.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 6`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Cat from './base/cat';
+export * from './base/cat';
+
+export default class Cat extends _Cat {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/cat.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 7`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Dog from './base/dog';
+export * from './base/dog';
+
+export default class Dog extends _Dog {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/dog.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 8`] = `
+Object {
+  "output": "/**
+ * generated from API definition file
+ */
+
+import Owner from './owner';
+import Breeder from './breeder';
+import Dog from './dog';
+import Cat from './cat';
+
+export {
+  Owner,
+  Breeder,
+  Dog,
+  Cat,
+};
+",
+  "path": "tmp/index.js",
+}
+`;
+
+exports[`model generator spec parse oneOf type 9`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Owner from './base/owner';
+export * from './base/owner';
+
+export default class Owner extends _Owner {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/owner.js",
+}
+`;

--- a/spec/generatemodels.test.js
+++ b/spec/generatemodels.test.js
@@ -34,4 +34,7 @@ describe('model generator spec', () => {
     snapshot('json_schema_ref.yml')
   });
 
+  test('parse oneOf type', () => {
+    snapshot('one_of.yml')
+  });
 });

--- a/spec/one_of.yml
+++ b/spec/one_of.yml
@@ -1,0 +1,80 @@
+---
+openapi: '3.0.0'
+info:
+  title: oneOf check
+  version: 1.0.0
+components:
+  schemas:
+    Owner:
+      description: Pet's owner
+      type: object
+      required:
+        - name
+      x-id-attribute: name
+      properties:
+        name:
+          description: owner name
+          type: string
+        pet:
+          $ref: '#/components/schemas/Pet'
+    Breeder:
+      description: Pet's breeder
+      type: object
+      required:
+        - name
+      x-id-attribute: name
+      properties:
+        name:
+          description: owner name
+          type: string
+        pets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pet'
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+      discriminator:
+        propertyName: kind
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: '#/components/schemas/Cat'
+    Dog:
+      description: Dog
+      type: object
+      required:
+        - id
+        - kind
+      properties:
+        id:
+          description: pet id
+          type: integer
+          format: int64
+        kind:
+          description: kind of pet
+          type: string
+          enum:
+            - dog
+        name:
+          description: name of pet
+          type: string
+    Cat:
+      description: Cat
+      type: object
+      required:
+        - id
+        - kind
+      properties:
+        id:
+          description: pet id
+          type: integer
+          format: int64
+        kind:
+          description: kind of pet
+          type: string
+          enum:
+            - cat
+        name:
+          description: name of pet
+          type: string

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -180,6 +180,14 @@ class ModelGenerator {
       };
     }
 
+    if (prop.type === 'array' && prop.items && prop.items.oneOf) {
+      const { propType, flow } = this.generateTypeFrom(prop.items, definition);
+      return {
+        propType: `ImmutablePropTypes.listOf(${propType})`,
+        flow: flow ? `(${flow})[]` : '',
+      };
+    }
+
     if (definition) {
       return {
         propType: this._generatePropTypeFromDefinition(definition),


### PR DESCRIPTION
#239 の対応

# before
```js
export default class Breeder extends Record(defaultValues) {
  name: string;
  pets: oneOfSchema1[];
  static denormalize(id: number[] | string[], entities: any) {
    return denormalize(id, entities);
  }
}
```

# after
https://github.com/eightcard/openapi-to-normalizr/pull/240/files#diff-802212065a0457058a74a9a50cb75757R258
```js
export default class Breeder extends Record(defaultValues) {
  name: string;
  pets: (Dog | Cat)[];
  static denormalize(id: number[] | string[], entities: any) {
    return denormalize(id, entities);
  }
}
```