### PR TITLE
:shirt: Fix api spec lint error

### DIFF
--- a/spec/one_of.yml
+++ b/spec/one_of.yml
@@ -3,6 +3,14 @@ openapi: '3.0.0'
 info:
   title: oneOf check
   version: 1.0.0
+  contact:
+    name: API Support
+    url: http://www.example.com/support
+    email: support@example.com
+tags:
+  - name: default
+    description: default API
+paths: {}
 components:
   schemas:
     Owner:


### PR DESCRIPTION
spec check is failed

```
yarn speclint
yarn run v1.6.0
$ find spec -name '*.yml' | xargs -I{} yarn speccy {}
$ speccy lint  spec/json_schema_ref.yml
(node:121) ExperimentalWarning: The http2 module is an experimental API.
Specification is valid, with 0 lint errors
$ speccy lint  spec/one_of.yml
(node:153) ExperimentalWarning: The http2 module is an experimental API.
Specification schema is invalid.

#/
expected Object {
  openapi: '3.0.0',
  info: Object { title: 'oneOf check', version: '1.0.0' },
  components: Object {
    schemas: Object {
  ... snip ...
	missing keys: paths
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
$ speccy lint  spec/only_components.yml
(node:184) ExperimentalWarning: The http2 module is an experimental API.
Specification is valid, with 0 lint errors
error Command failed with exit code 123.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Exited with code 1
```