### PR TITLE
外部ファイルを参照したoneOfに対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test": "jest src/lib spec",
     "jest": "jest",
     "flow": "flow tmp",
-    "speclint": "find spec -name '*.yml' | xargs -I{} yarn speccy {}",
-    "speccy": "speccy lint "
+    "speclint": "find spec examples -name '*.yml' | xargs -I{} yarn speccy {}",
+    "speccy": "speccy lint -s 'operation-operationId' "
   }
 }

--- a/spec/__snapshots__/command.test.js.snap
+++ b/spec/__snapshots__/command.test.js.snap
@@ -189,7 +189,6 @@ export default {
         \\"tags\\": [
           \\"pet\\"
         ],
-        \\"operationId\\": \\"getPet\\",
         \\"description\\": \\"get pet\\\\n\\",
         \\"parameters\\": [
           {
@@ -609,7 +608,6 @@ export default {
         \\"tags\\": [
           \\"owner\\"
         ],
-        \\"operationId\\": \\"getOwner\\",
         \\"description\\": \\"get pet\\\\n\\",
         \\"parameters\\": [
           {

--- a/spec/__snapshots__/command.test.js.snap
+++ b/spec/__snapshots__/command.test.js.snap
@@ -774,3 +774,268 @@ export default {
   "path": "tmp/schemas/sample_schema.js",
 }
 `;
+
+exports[`schema generator spec from one of other spec file  check 1`] = `
+Object {
+  "output": "/* eslint-disable no-underscore-dangle */
+/**
+ * generated from API definition file
+ */
+
+import isFunction from 'lodash/isFunction';
+import { createAction } from 'redux-actions';
+import schemas from '../schemas/sample_schema';
+export const GET_PETS__ID_ = 'GET_PETS__ID_';
+
+export function createOpenApiAction(id, payloadCreator = (params) => params, metaCreator) {
+  const meta = {openApi: true, id: id.toLowerCase(), schema: schemas[id.toLowerCase()]};
+  let _metaCreator = () => meta;
+  if (isFunction(metaCreator)) {
+    _metaCreator = (...args) => Object.assign(metaCreator(...args), meta);
+  }
+  return createAction(id, payloadCreator, _metaCreator);
+}
+",
+  "path": "tmp/action_types/sample.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 2`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+
+export const KIND_CAT: string = 'cat';
+
+const defaultValues = {
+  id: undefined,
+  kind: undefined,
+  name: undefined,
+};
+
+export const schema = new _schema.Entity('Cat', {}, {idAttribute: 'id'});
+
+
+/**
+ * @params ids : Cat's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Cat extends Record(defaultValues) {
+  id: number;
+  kind: string;
+  name: string;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/cat.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 3`] = `
+Object {
+  "output": "/* eslint-disable */
+// @flow
+/**
+ * generated from API definition file
+ */
+
+import { Record, List } from 'immutable';
+import { schema as _schema, denormalize as _denormalize } from 'normalizr';
+import isArray from 'lodash/isArray';
+
+export const KIND_DOG: string = 'dog';
+
+const defaultValues = {
+  id: undefined,
+  kind: undefined,
+  name: undefined,
+};
+
+export const schema = new _schema.Entity('Dog', {}, {idAttribute: 'id'});
+
+
+/**
+ * @params ids : Dog's id[s]
+ * @params entities : all entities that need to denormalize ids
+ */
+export const denormalize = (ids: number[] | string[], entities: any) => _denormalize(ids, isArray(ids) || List.isList(ids) ? [schema] : schema, entities);
+
+export default class Dog extends Record(defaultValues) {
+  id: number;
+  kind: string;
+  name: string;
+  static denormalize(id: number[] | string[], entities: any) {
+    return denormalize(id, entities);
+  }
+}
+",
+  "path": "tmp/base/dog.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 4`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Cat from './base/cat';
+export * from './base/cat';
+
+export default class Cat extends _Cat {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/cat.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 5`] = `
+Object {
+  "output": "/* eslint-disable comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+import _Dog from './base/dog';
+export * from './base/dog';
+
+export default class Dog extends _Dog {
+
+  /**
+   * write custom methods here
+   */
+}
+",
+  "path": "tmp/dog.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 6`] = `
+Object {
+  "output": "/**
+ * generated from API definition file
+ */
+
+import Dog from './dog';
+import Cat from './cat';
+
+export {
+  Dog,
+  Cat,
+};
+",
+  "path": "tmp/index.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 7`] = `
+Object {
+  "output": "/* eslint-disable quotes,comma-dangle */
+/**
+ * generated from API definition file
+ */
+
+export default {
+  \\"openapi\\": \\"3.0.0\\",
+  \\"info\\": {
+    \\"title\\": \\"read one of schema from other file\\",
+    \\"version\\": \\"1.0.0\\",
+    \\"contact\\": {
+      \\"name\\": \\"API Support\\",
+      \\"url\\": \\"http://www.example.com/support\\",
+      \\"email\\": \\"support@example.com\\"
+    }
+  },
+  \\"tags\\": [
+    {
+      \\"name\\": \\"default\\",
+      \\"description\\": \\"default API\\"
+    }
+  ],
+  \\"paths\\": {
+    \\"/pets/{id}\\": {
+      \\"get\\": {
+        \\"tags\\": [
+          \\"pet\\"
+        ],
+        \\"description\\": \\"get pet\\\\n\\",
+        \\"parameters\\": [
+          {
+            \\"description\\": \\"pet id\\",
+            \\"name\\": \\"id\\",
+            \\"in\\": \\"path\\",
+            \\"required\\": true,
+            \\"schema\\": {
+              \\"type\\": \\"integer\\",
+              \\"format\\": \\"int64\\"
+            }
+          }
+        ],
+        \\"responses\\": {
+          \\"200\\": {
+            \\"$ref\\": \\"#/components/responses/PetResponse\\"
+          }
+        }
+      }
+    }
+  },
+  \\"components\\": {
+    \\"responses\\": {
+      \\"PetResponse\\": {
+        \\"description\\": \\"a pet response\\",
+        \\"content\\": {
+          \\"application/json\\": {
+            \\"schema\\": {
+              \\"$ref\\": \\"./one_of.yml#/components/schemas/Pet\\"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+",
+  "path": "tmp/sample_api.js",
+}
+`;
+
+exports[`schema generator spec from one of other spec file  check 8`] = `
+Object {
+  "output": "/* eslint-disable */
+/**
+ * generated from API definition file
+ */
+
+import { schema as DogSchema } from './../dog';
+import { schema as CatSchema } from './../cat';
+import { schema as _schema } from 'normalizr';
+const oneOfSchema1 = new _schema.Union({
+  dog: DogSchema,
+  cat: CatSchema
+}, 'kind');
+
+export default {
+  get_pets__id_: {
+    200: oneOfSchema1
+  }
+};
+",
+  "path": "tmp/schemas/sample_schema.js",
+}
+`;

--- a/spec/command.test.js
+++ b/spec/command.test.js
@@ -37,4 +37,8 @@ describe('schema generator spec', () => {
   test('from one of check', () => {
     snapshot('generateschemas', ['one_of.yml'])
   });
+
+  test('from one of other spec file  check', () => {
+    snapshot('generateschemas', ['one_of_from_other_file.yml'])
+  });
 });

--- a/spec/json_schema_ref.yml
+++ b/spec/json_schema_ref.yml
@@ -17,7 +17,6 @@ paths:
     get:
       tags:
         - pet
-      operationId: getPet
       description: |
         get pet
       parameters:

--- a/spec/one_of.yml
+++ b/spec/one_of.yml
@@ -15,7 +15,6 @@ paths:
     get:
       tags:
         - owner
-      operationId: getOwner
       description: |
         get pet
       parameters:

--- a/spec/one_of_from_other_file.yml
+++ b/spec/one_of_from_other_file.yml
@@ -1,0 +1,38 @@
+---
+openapi: '3.0.0'
+info:
+  title: read one of schema from other file
+  version: 1.0.0
+  contact: 
+    name: API Support
+    url: http://www.example.com/support
+    email: support@example.com
+tags:
+  - name: default
+    description: default API
+paths:
+  /pets/{id}:
+    get:
+      tags:
+        - pet
+      description: |
+        get pet
+      parameters:
+        - description: pet id
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          $ref: '#/components/responses/PetResponse'
+components:
+  responses:
+    PetResponse:
+      description: a pet response
+      content:
+        application/json:
+          schema:
+            $ref: './one_of.yml#/components/schemas/Pet'

--- a/src/tools/model_generator.js
+++ b/src/tools/model_generator.js
@@ -187,8 +187,8 @@ class ModelGenerator {
   generateTypeFrom(prop, definition) {
     if (prop && prop.oneOf) {
       const candidates = prop.oneOf.map((obj) => {
-        const ref = obj.$ref || obj.$$ref;
-        return ref ? { isModel: true, type: getModelName(obj) } : { isModel: false, type: obj.type };
+        const modelName = getModelName(obj);
+        return modelName ? { isModel: true, type: modelName } : { isModel: false, type: obj.type };
       });
       return {
         propType: `PropTypes.oneOfType([${_.uniq(candidates.map(c => c.isModel ? `${c.type}PropType` : _getPropTypes(c.type))).join(', ')}])`,


### PR DESCRIPTION
## 目的
- 外部ファイルを参照するような oneOf は derefercence時に情報($ref)が欠けており、パースできなくなっている。 [こういうパターン](https://github.com/eightcard/openapi-to-normalizr/compare/fix/one_of_parse_from_other_file#diff-b1955b2390268ebf9c317ccd4a17ae50R38)

## 対応
- 事前のファイル準備時点で `$ref` を別のキーで保持することで dereference 後も利用できるようにする。