### PR TITLE
required取得のためにOpenAPI記法パース済みの情報を利用する

### DIFF
--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -8,7 +8,7 @@ const path = require('path');
 const Swagger = require('swagger-client');
 const program = require('commander');
 const _ = require('lodash');
-const { resolvePath, mkdirpPromise, readSpecFilePromise, getPreparedSpecFiles } = require('../src/tools/utils');
+const { resolvePath, mkdirpPromise, readSpecFilePromise, getPreparedSpecFilePaths, getModelDefinitions } = require('../src/tools/utils');
 const ModelGenerator = require('../src/tools/model_generator');
 const SchemaGenerator = require('../src/tools/schema_generator');
 const ActionTypesGenerator = require('../src/tools/action_types_generator');
@@ -37,9 +37,9 @@ console.log(`
     js-spec    : ${config.outputPath.jsSpec}
 `);
 
-const { filesPath, definitions} = getPreparedSpecFiles(specFiles);
+const filePaths = getPreparedSpecFilePaths(specFiles);
 
-Promise.all(filesPath.map((file) => readSpecFilePromise(file, {dereference: true}))).then((schemas) => {
+Promise.all(filePaths.map((file) => readSpecFilePromise(file, {dereference: true}))).then((schemas) => {
   const spec = _.merge(...schemas);
 
   let actionTypesGenerator, modelGenerator, schemaGenerator;
@@ -49,6 +49,9 @@ Promise.all(filesPath.map((file) => readSpecFilePromise(file, {dereference: true
   const prepareDirs = [actionsDir, schemasDir, specDir, modelsDir, baseModelsDir].map((p) => mkdirpPromise(p));
 
   return Swagger({spec}).then(({spec}) => {
+    // refとOpenAPI記法(oneOfなど)解決済みのspecからモデル定義を取得
+    const definitions = getModelDefinitions(spec);
+
     return Promise.all(prepareDirs).then(() => {
       const isV2 = spec.swagger === '2.0';
       const attributeConverter = config.attributeConverter ? config.attributeConverter : str => str;


### PR DESCRIPTION
Specを`Swagger` などでパースする前の情報は `oneOf` や `allOf` が解決されていない。
このため以下のようなパターンでモデルとしての `required` が反映されていない場合がある。
```yml
components:
  schemas:
    Pet:
      allOf:
         - description: Pet
            type: object
         - required:
              - id
           properties:
              id:
                description: pet id
                type: integer
                format: int64
```
先に `Swagger` でのパースを実施したあとでモデル定義を取得するようにする