### PR TITLE
タグによる利用OperationPath指定を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,6 +39,7 @@
         useFlow: 'flowtype利用(true/false)',
         usePropType: 'prop-type利用(true/false)',
         attributeConverter: '属性コンバート用関数',
+        tags: ['xxx', 'yyy'], // 指定したタグで生成対象を制限(未指定時はすべてのパスが対象)
       }
       ```
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ npm install git+ssh://git@github.com/eightcard/openapi-to-normalizr.git
     useFlow: 'use flowtype?(true/false)', // default: false (experiment)
     usePropType: 'use prop-type?(true/false)',  // default: true
     attributeConverter: 'attribute converter function',
+    tags: ['xxx', 'yyy'], // all path include target without tags
   }
   ```
 

--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -45,7 +45,7 @@ console.log(`
     js-spec    : ${config.outputPath.jsSpec}
 `);
 
-const filePaths = getPreparedSpecFilePaths(specFiles);
+const filePaths = getPreparedSpecFilePaths(specFiles, config.tags);
 
 Promise.all(filePaths.map((file) => readSpecFilePromise(file, {dereference: true}))).then((schemas) => {
   const spec = _.merge(...schemas);

--- a/src/tools/config.js
+++ b/src/tools/config.js
@@ -5,6 +5,10 @@ class Config {
     this.modelsDir = config.modelsDir || 'dist';
   }
 
+  get tags() {
+    return this._config.tags;
+  }
+
   get outputPath() {
     return this._config.outputPath;
   }


### PR DESCRIPTION
configに `tags: ['xxx', 'yyy']` を追記することで自動生成対象を指定できるようにする