### PR TITLE
ConfigをTSに変換する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,10 +5,15 @@ module.exports = {
     node: true,
   },
   extends: [
+    /* ESLintの推奨ルール */
     'eslint:recommended',
+    /* ESLintチームが作ったTS用の推奨ルール */
     'plugin:@typescript-eslint/eslint-recommended',
+    /* TS用の推奨ルール */
     'plugin:@typescript-eslint/recommended',
+    /* Prettierのルールと競合するものを無効化 */
     'prettier',
+    /* PrettierのTS用のルールと競合するものを無効化 */
     'prettier/@typescript-eslint',
   ],
   plugins: ['@typescript-eslint'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,19 @@ module.exports = {
     es6: true,
     node: true,
   },
-  extends: ['eslint:recommended', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'prettier/@typescript-eslint',
+  ],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 2019,
+    project: './tsconfig.json',
   },
   globals: {
     jest: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,5 +260,6 @@ module.exports = {
     'wrap-regex': 'error',
     'yield-star-spacing': 'error',
     yoda: ['error', 'never'],
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
 };

--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -19,7 +19,7 @@ const TsModelGenerator = require('../src/tools/ts_model_generator');
 const SchemaGenerator = require('../src/tools/schema_generator');
 const ActionTypesGenerator = require('../src/tools/action_types_generator');
 const JsSpecGenerator = require('../src/tools/js_spec_generator');
-const Config = require('../src/tools/config');
+const Config = require('../dist/compiled/config');
 
 program
   .option('-c, --config <configPath>', 'config path')

--- a/dist/compiled/config.js
+++ b/dist/compiled/config.js
@@ -1,0 +1,61 @@
+"use strict";
+class Config {
+    constructor(config) {
+        this._config = config;
+        this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
+        this.modelsDir = config.modelsDir || 'dist';
+    }
+    get tags() {
+        return this._config.tags;
+    }
+    get outputPath() {
+        return this._config.outputPath;
+    }
+    get useTypeScript() {
+        return this._config.useTypeScript;
+    }
+    get extension() {
+        return this._config.useTypeScript ? 'ts' : 'js';
+    }
+    formatForModelGenerator() {
+        const { modelsDir: outputDir, templates: templatePath, usePropType, useTypeScript, attributeConverter, } = this._config;
+        return {
+            outputDir,
+            templatePath,
+            usePropType,
+            useTypeScript,
+            attributeConverter,
+            extension: this.extension,
+        };
+    }
+    formatForActionTypesGenerator() {
+        const { outputPath, templates: templatePath, useTypeScript } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.actions,
+            schemasFilePath: outputPath.schemas,
+            useTypeScript,
+            extension: this.extension,
+        };
+    }
+    formatForSchemaGenerator() {
+        const { outputPath, templates: templatePath, modelsDir, attributeConverter, useTypeScript, } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.schemas,
+            modelsDir,
+            attributeConverter,
+            useTypeScript,
+            extension: this.extension,
+        };
+    }
+    formatForJsSpecGenerator() {
+        const { templates: templatePath, outputPath } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.jsSpec,
+            extension: this.extension,
+        };
+    }
+}
+module.exports = Config;

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,7 +13,9 @@ var _immutable = _interopRequireWildcard(require("immutable"));
 
 var _normalizr = _interopRequireWildcard(require("normalizr"));
 
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; if (obj != null) { var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
 
 var immutable = _immutable;
 exports.immutable = immutable;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "@types/prop-types": "15.7.3",
     "@types/react-immutable-proptypes": "2.1.0",
     "@types/redux-actions": "2.6.1",
+    "@typescript-eslint/eslint-plugin": "2.5.0",
+    "@typescript-eslint/parser": "2.5.0",
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-polyfill": "6.26.0",
@@ -101,7 +103,7 @@
   "main": "dist/index.js",
   "repository": "eightcard/openapi-to-normalizr",
   "scripts": {
-    "build:dist": "yarn eslint && yarn test && babel -d dist --env-name=development src/lib/**/*[^test].js",
+    "build:dist": "yarn eslint && yarn test && tsc && babel -d dist --env-name=development src/lib/**/*[^test].js",
     "build:sample": "webpack --config examples/webpack.config.babel.js --progress",
     "build:sample:schemas": "./bin/generateschemas --config examples/config/config.schemas.js",
     "check:typescript": "tsc --noEmit",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,15 @@
+declare type AttributeConverter = (s: string) => string;
+
+declare interface ConfigObject {
+  templates: {
+    [K: string]: string;
+  };
+  outputPath: {
+    [K: string]: string;
+  };
+  modelsDir?: string;
+  tags?: string[];
+  attributeConverter?: AttributeConverter;
+  usePropType: boolean;
+  useTypeScript: boolean;
+}

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -1,5 +1,11 @@
 class Config {
-  constructor(config) {
+  _config: ConfigObject;
+
+  attributeConverter: AttributeConverter;
+
+  modelsDir: string;
+
+  constructor(config: ConfigObject) {
     this._config = config;
     this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
     this.modelsDir = config.modelsDir || 'dist';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,14 @@
     "target": "ESNEXT",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "es2015",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2015", "es2015.iterable"],                             /* Specify library files to be included in the compilation. */
-    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist/compiled",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "incremental": true,                   /* Enable incremental compilation */
@@ -58,5 +58,11 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tmp",
+    "examples",
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1263,7 +1268,7 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/json-schema@7.0.3":
+"@types/json-schema@7.0.3", "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
@@ -1322,6 +1327,47 @@
   integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.5.0.tgz#101d96743ce3365b3223df73d641078c9b775903"
+  integrity sha512-ddrJZxp5ns1Lh5ofZQYk3P8RyvKfyz/VcRR4ZiJLHO/ljnQAO8YvTfj268+WJOOadn99mvDiqJA65+HAKoeSPA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    eslint-utils "^1.4.2"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.5.0.tgz#383a97ded9a7940e5053449f6d73995e782b8fb1"
+  integrity sha512-UgcQGE0GKJVChyRuN1CWqDW8Pnu7+mVst0aWrhiyuUD1J9c+h8woBdT4XddCvhcXDodTDVIfE3DzGHVjp7tUeQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.5.0.tgz#858030ddd808fbbe88e03f42e5971efaccb8218a"
+  integrity sha512-9UBMiAwIDWSl79UyogaBdj3hidzv6exjKUx60OuZuFnJf56tq/UMpdPcX09YmGqE8f4AnAueYtBxV8IcAT3jdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.5.0.tgz#40ada624d6217ef092a3a79ed30d947ad4f212ce"
+  integrity sha512-AXURyF8NcA3IsnbjNX1v9qbwa0dDoY9YPcKYR2utvMHoUcu3636zrz0gRWtVAyxbPCkhyKuGg6WZIyi2Fc79CA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -5790,6 +5836,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash@4, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -8847,10 +8898,22 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+tslib@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
# 背景

TSを書く環境が整ったので、試しにJSファイルをTSファイルに書き直してみる。

# 実装

- tscコマンドでTSファイルをコンパイルし、dist/compiledに出力
- `bin/generateschemas` ではcompileされたJSファイルを使う
  - これによりJestでTSを使うのは回避する（ちょっと難しそうだったので）
- ESLintにTS用のルールなどを追加