### PR TITLE
checkoutとmerge後にyarnするhuskyのhookを消す

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,9 +71,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged --allow-empty",
-      "post-checkout": "yarn",
-      "post-merge": "yarn"
+      "pre-commit": "lint-staged --allow-empty"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
VSCodeでcheckoutとかすると、毎回時間かかってイライラするので入れといてなんですが、消したいです。
自己責任で必要な時は各々`yarn`してもらう感じで