### PR TITLE
Convert all JS files in `tools` folder to TS (with `@ts-nocheck`)

### DIFF
--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -8,16 +8,16 @@ const path = require('path');
 const Swagger = require('swagger-client');
 const program = require('commander');
 const _ = require('lodash');
-const { resolvePath, mkdirpPromise, getModelDefinitions } = require('../src/tools/utils');
+const { resolvePath, mkdirpPromise, getModelDefinitions } = require('../dist/compiled/utils');
 const {
   readSpecFilePromise,
   getPreparedSpecFilePaths,
   convertToLocalDefinition,
 } = require('../dist/compiled/spec_file_utils');
-const ModelGenerator = require('../src/tools/model_generator');
-const SchemaGenerator = require('../src/tools/schema_generator');
-const ActionTypesGenerator = require('../src/tools/action_types_generator');
-const JsSpecGenerator = require('../src/tools/js_spec_generator');
+const ModelGenerator = require('../dist/compiled/model_generator');
+const SchemaGenerator = require('../dist/compiled/schema_generator');
+const ActionTypesGenerator = require('../dist/compiled/action_types_generator');
+const JsSpecGenerator = require('../dist/compiled/js_spec_generator');
 const Config = require('../dist/compiled/config');
 
 program

--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -14,11 +14,11 @@ const {
   getPreparedSpecFilePaths,
   convertToLocalDefinition,
 } = require('../dist/compiled/spec_file_utils');
-const ModelGenerator = require('../dist/compiled/model_generator');
-const SchemaGenerator = require('../dist/compiled/schema_generator');
-const ActionTypesGenerator = require('../dist/compiled/action_types_generator');
-const JsSpecGenerator = require('../dist/compiled/js_spec_generator');
-const Config = require('../dist/compiled/config');
+const ModelGenerator = require('../dist/compiled/model_generator').default;
+const SchemaGenerator = require('../dist/compiled/schema_generator').default;
+const ActionTypesGenerator = require('../dist/compiled/action_types_generator').default;
+const JsSpecGenerator = require('../dist/compiled/js_spec_generator').default;
+const Config = require('../dist/compiled/config').default;
 
 program
   .option('-c, --config <configPath>', 'config path')

--- a/dist/compiled/action_types_generator.js
+++ b/dist/compiled/action_types_generator.js
@@ -46,5 +46,5 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
         }
     }
-    module.exports = ActionTypesGenerator;
+    exports.default = ActionTypesGenerator;
 });

--- a/dist/compiled/action_types_generator.js
+++ b/dist/compiled/action_types_generator.js
@@ -1,0 +1,50 @@
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "path", "./utils"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    // @ts-nocheck
+    const path_1 = __importDefault(require("path"));
+    const utils_1 = require("./utils");
+    class ActionTypesGenerator {
+        constructor({ outputPath = '', schemasFilePath = '', templatePath = {}, operationIdList = [], useTypeScript = false, extension = 'js', }) {
+            this.outputPath = outputPath;
+            const { dir, name, ext } = path_1.default.parse(this.outputPath);
+            this.outputDir = dir;
+            this.outputFileName = `${name}.${extension}`;
+            this.schemasFilePath = schemasFilePath.replace(ext, '');
+            this.templatePath = templatePath;
+            this.operationIdList = operationIdList;
+            this.templates = utils_1.readTemplates(['head', 'actionTypes'], this.templatePath);
+            this.appendId = this.appendId.bind(this);
+            this.write = this.write.bind(this);
+            this.useTypeScript = useTypeScript;
+        }
+        appendId(id) {
+            this.operationIdList.push(id.toUpperCase());
+        }
+        /**
+         * actionTypes.jsを書き出し
+         */
+        write() {
+            const text = utils_1.render(this.templates.actionTypes, {
+                operationIdList: this.operationIdList,
+                schemasFile: path_1.default.relative(this.outputDir, this.schemasFilePath),
+                useTypeScript: this.useTypeScript,
+            }, {
+                head: this.templates.head,
+            });
+            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
+        }
+    }
+    module.exports = ActionTypesGenerator;
+});

--- a/dist/compiled/action_types_generator.js
+++ b/dist/compiled/action_types_generator.js
@@ -1,50 +1,40 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+Object.defineProperty(exports, "__esModule", { value: true });
+// @ts-nocheck
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("./utils");
+class ActionTypesGenerator {
+    constructor({ outputPath = '', schemasFilePath = '', templatePath = {}, operationIdList = [], useTypeScript = false, extension = 'js', }) {
+        this.outputPath = outputPath;
+        const { dir, name, ext } = path_1.default.parse(this.outputPath);
+        this.outputDir = dir;
+        this.outputFileName = `${name}.${extension}`;
+        this.schemasFilePath = schemasFilePath.replace(ext, '');
+        this.templatePath = templatePath;
+        this.operationIdList = operationIdList;
+        this.templates = utils_1.readTemplates(['head', 'actionTypes'], this.templatePath);
+        this.appendId = this.appendId.bind(this);
+        this.write = this.write.bind(this);
+        this.useTypeScript = useTypeScript;
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "path", "./utils"], factory);
+    appendId(id) {
+        this.operationIdList.push(id.toUpperCase());
     }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    // @ts-nocheck
-    const path_1 = __importDefault(require("path"));
-    const utils_1 = require("./utils");
-    class ActionTypesGenerator {
-        constructor({ outputPath = '', schemasFilePath = '', templatePath = {}, operationIdList = [], useTypeScript = false, extension = 'js', }) {
-            this.outputPath = outputPath;
-            const { dir, name, ext } = path_1.default.parse(this.outputPath);
-            this.outputDir = dir;
-            this.outputFileName = `${name}.${extension}`;
-            this.schemasFilePath = schemasFilePath.replace(ext, '');
-            this.templatePath = templatePath;
-            this.operationIdList = operationIdList;
-            this.templates = utils_1.readTemplates(['head', 'actionTypes'], this.templatePath);
-            this.appendId = this.appendId.bind(this);
-            this.write = this.write.bind(this);
-            this.useTypeScript = useTypeScript;
-        }
-        appendId(id) {
-            this.operationIdList.push(id.toUpperCase());
-        }
-        /**
-         * actionTypes.jsを書き出し
-         */
-        write() {
-            const text = utils_1.render(this.templates.actionTypes, {
-                operationIdList: this.operationIdList,
-                schemasFile: path_1.default.relative(this.outputDir, this.schemasFilePath),
-                useTypeScript: this.useTypeScript,
-            }, {
-                head: this.templates.head,
-            });
-            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
-        }
+    /**
+     * actionTypes.jsを書き出し
+     */
+    write() {
+        const text = utils_1.render(this.templates.actionTypes, {
+            operationIdList: this.operationIdList,
+            schemasFile: path_1.default.relative(this.outputDir, this.schemasFilePath),
+            useTypeScript: this.useTypeScript,
+        }, {
+            head: this.templates.head,
+        });
+        return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
     }
-    exports.default = ActionTypesGenerator;
-});
+}
+exports.default = ActionTypesGenerator;

--- a/dist/compiled/config.js
+++ b/dist/compiled/config.js
@@ -1,61 +1,72 @@
-"use strict";
-class Config {
-    constructor(config) {
-        this._config = config;
-        this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
-        this.modelsDir = config.modelsDir || 'dist';
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
     }
-    get tags() {
-        return this._config.tags;
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
     }
-    get outputPath() {
-        return this._config.outputPath;
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    class Config {
+        constructor(config) {
+            this._config = config;
+            this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
+            this.modelsDir = config.modelsDir || 'dist';
+        }
+        get tags() {
+            return this._config.tags;
+        }
+        get outputPath() {
+            return this._config.outputPath;
+        }
+        get useTypeScript() {
+            return this._config.useTypeScript;
+        }
+        get extension() {
+            return this._config.useTypeScript ? 'ts' : 'js';
+        }
+        formatForModelGenerator() {
+            const { modelsDir: outputDir, templates: templatePath, usePropType, useTypeScript, attributeConverter, } = this._config;
+            return {
+                outputDir,
+                templatePath,
+                usePropType,
+                useTypeScript,
+                attributeConverter,
+                extension: this.extension,
+            };
+        }
+        formatForActionTypesGenerator() {
+            const { outputPath, templates: templatePath, useTypeScript } = this._config;
+            return {
+                templatePath,
+                outputPath: outputPath.actions,
+                schemasFilePath: outputPath.schemas,
+                useTypeScript,
+                extension: this.extension,
+            };
+        }
+        formatForSchemaGenerator() {
+            const { outputPath, templates: templatePath, modelsDir, attributeConverter, useTypeScript, } = this._config;
+            return {
+                templatePath,
+                outputPath: outputPath.schemas,
+                modelsDir,
+                attributeConverter,
+                useTypeScript,
+                extension: this.extension,
+            };
+        }
+        formatForJsSpecGenerator() {
+            const { templates: templatePath, outputPath } = this._config;
+            return {
+                templatePath,
+                outputPath: outputPath.jsSpec,
+                extension: this.extension,
+            };
+        }
     }
-    get useTypeScript() {
-        return this._config.useTypeScript;
-    }
-    get extension() {
-        return this._config.useTypeScript ? 'ts' : 'js';
-    }
-    formatForModelGenerator() {
-        const { modelsDir: outputDir, templates: templatePath, usePropType, useTypeScript, attributeConverter, } = this._config;
-        return {
-            outputDir,
-            templatePath,
-            usePropType,
-            useTypeScript,
-            attributeConverter,
-            extension: this.extension,
-        };
-    }
-    formatForActionTypesGenerator() {
-        const { outputPath, templates: templatePath, useTypeScript } = this._config;
-        return {
-            templatePath,
-            outputPath: outputPath.actions,
-            schemasFilePath: outputPath.schemas,
-            useTypeScript,
-            extension: this.extension,
-        };
-    }
-    formatForSchemaGenerator() {
-        const { outputPath, templates: templatePath, modelsDir, attributeConverter, useTypeScript, } = this._config;
-        return {
-            templatePath,
-            outputPath: outputPath.schemas,
-            modelsDir,
-            attributeConverter,
-            useTypeScript,
-            extension: this.extension,
-        };
-    }
-    formatForJsSpecGenerator() {
-        const { templates: templatePath, outputPath } = this._config;
-        return {
-            templatePath,
-            outputPath: outputPath.jsSpec,
-            extension: this.extension,
-        };
-    }
-}
-module.exports = Config;
+    exports.default = Config;
+});

--- a/dist/compiled/config.js
+++ b/dist/compiled/config.js
@@ -1,72 +1,62 @@
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class Config {
+    constructor(config) {
+        this._config = config;
+        this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
+        this.modelsDir = config.modelsDir || 'dist';
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports"], factory);
+    get tags() {
+        return this._config.tags;
     }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    class Config {
-        constructor(config) {
-            this._config = config;
-            this.attributeConverter = config.attributeConverter ? config.attributeConverter : (str) => str;
-            this.modelsDir = config.modelsDir || 'dist';
-        }
-        get tags() {
-            return this._config.tags;
-        }
-        get outputPath() {
-            return this._config.outputPath;
-        }
-        get useTypeScript() {
-            return this._config.useTypeScript;
-        }
-        get extension() {
-            return this._config.useTypeScript ? 'ts' : 'js';
-        }
-        formatForModelGenerator() {
-            const { modelsDir: outputDir, templates: templatePath, usePropType, useTypeScript, attributeConverter, } = this._config;
-            return {
-                outputDir,
-                templatePath,
-                usePropType,
-                useTypeScript,
-                attributeConverter,
-                extension: this.extension,
-            };
-        }
-        formatForActionTypesGenerator() {
-            const { outputPath, templates: templatePath, useTypeScript } = this._config;
-            return {
-                templatePath,
-                outputPath: outputPath.actions,
-                schemasFilePath: outputPath.schemas,
-                useTypeScript,
-                extension: this.extension,
-            };
-        }
-        formatForSchemaGenerator() {
-            const { outputPath, templates: templatePath, modelsDir, attributeConverter, useTypeScript, } = this._config;
-            return {
-                templatePath,
-                outputPath: outputPath.schemas,
-                modelsDir,
-                attributeConverter,
-                useTypeScript,
-                extension: this.extension,
-            };
-        }
-        formatForJsSpecGenerator() {
-            const { templates: templatePath, outputPath } = this._config;
-            return {
-                templatePath,
-                outputPath: outputPath.jsSpec,
-                extension: this.extension,
-            };
-        }
+    get outputPath() {
+        return this._config.outputPath;
     }
-    exports.default = Config;
-});
+    get useTypeScript() {
+        return this._config.useTypeScript;
+    }
+    get extension() {
+        return this._config.useTypeScript ? 'ts' : 'js';
+    }
+    formatForModelGenerator() {
+        const { modelsDir: outputDir, templates: templatePath, usePropType, useTypeScript, attributeConverter, } = this._config;
+        return {
+            outputDir,
+            templatePath,
+            usePropType,
+            useTypeScript,
+            attributeConverter,
+            extension: this.extension,
+        };
+    }
+    formatForActionTypesGenerator() {
+        const { outputPath, templates: templatePath, useTypeScript } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.actions,
+            schemasFilePath: outputPath.schemas,
+            useTypeScript,
+            extension: this.extension,
+        };
+    }
+    formatForSchemaGenerator() {
+        const { outputPath, templates: templatePath, modelsDir, attributeConverter, useTypeScript, } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.schemas,
+            modelsDir,
+            attributeConverter,
+            useTypeScript,
+            extension: this.extension,
+        };
+    }
+    formatForJsSpecGenerator() {
+        const { templates: templatePath, outputPath } = this._config;
+        return {
+            templatePath,
+            outputPath: outputPath.jsSpec,
+            extension: this.extension,
+        };
+    }
+}
+exports.default = Config;

--- a/dist/compiled/js_spec_generator.js
+++ b/dist/compiled/js_spec_generator.js
@@ -1,87 +1,77 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+Object.defineProperty(exports, "__esModule", { value: true });
+// @ts-nocheck
+const path_1 = __importDefault(require("path"));
+const lodash_1 = __importDefault(require("lodash"));
+const utils_1 = require("./utils");
+const spec_file_utils_1 = require("./spec_file_utils");
+const UNNECESSARY_PROPS = [
+    spec_file_utils_1.ALTERNATIVE_REF_KEY,
+    'description',
+    'info',
+    spec_file_utils_1.MODEL_DEF_KEY,
+    'x-id-attribute',
+    'x-attribute-as',
+    'x-enum-key-attributes',
+];
+class JsSpecGenerator {
+    constructor({ outputPath = '', templatePath, extension = 'js' }) {
+        this.outputPath = outputPath;
+        this.templatePath = templatePath;
+        this.templates = utils_1.readTemplates(['spec', 'head'], this.templatePath);
+        const { dir, name } = path_1.default.parse(this.outputPath);
+        this.outputDir = dir;
+        this.outputFileName = `${name}.${extension}`;
+        this.write = this.write.bind(this);
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "path", "lodash", "./utils", "./spec_file_utils"], factory);
+    write(spec) {
+        this.deleteUnnecessaryProps(spec);
+        this.deleteUnusedComponents(spec);
+        const text = utils_1.render(this.templates.spec, {
+            spec: JSON.stringify(spec, null, 2),
+        }, {
+            head: this.templates.head,
+        });
+        return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
     }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    // @ts-nocheck
-    const path_1 = __importDefault(require("path"));
-    const lodash_1 = __importDefault(require("lodash"));
-    const utils_1 = require("./utils");
-    const spec_file_utils_1 = require("./spec_file_utils");
-    const UNNECESSARY_PROPS = [
-        spec_file_utils_1.ALTERNATIVE_REF_KEY,
-        'description',
-        'info',
-        spec_file_utils_1.MODEL_DEF_KEY,
-        'x-id-attribute',
-        'x-attribute-as',
-        'x-enum-key-attributes',
-    ];
-    class JsSpecGenerator {
-        constructor({ outputPath = '', templatePath, extension = 'js' }) {
-            this.outputPath = outputPath;
-            this.templatePath = templatePath;
-            this.templates = utils_1.readTemplates(['spec', 'head'], this.templatePath);
-            const { dir, name } = path_1.default.parse(this.outputPath);
-            this.outputDir = dir;
-            this.outputFileName = `${name}.${extension}`;
-            this.write = this.write.bind(this);
-        }
-        write(spec) {
-            this.deleteUnnecessaryProps(spec);
-            this.deleteUnusedComponents(spec);
-            const text = utils_1.render(this.templates.spec, {
-                spec: JSON.stringify(spec, null, 2),
-            }, {
-                head: this.templates.head,
+    deleteUnnecessaryProps(spec) {
+        spec_file_utils_1.walkSchema(spec, (obj) => {
+            UNNECESSARY_PROPS.forEach((key) => delete obj[key]);
+        });
+    }
+    deleteUnusedComponents(spec) {
+        const useRefs = {};
+        // pathから利用しているrefを取得
+        spec_file_utils_1.walkSchema(spec.paths, (obj) => {
+            if (obj.$ref)
+                useRefs[obj.$ref] = true;
+        });
+        // pathで利用しているrefから芋づる式に利用しているrefを取得
+        lodash_1.default.each(useRefs, (_bool, ref) => checkRef(ref));
+        // ↑で取得した以外のcomponents情報を削除
+        lodash_1.default.each(spec.components, (schemas, key) => {
+            lodash_1.default.each(schemas, (_obj, name) => {
+                const p = `#/components/${key}/${name}`;
+                if (!useRefs[p])
+                    delete schemas[name];
             });
-            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
-        }
-        deleteUnnecessaryProps(spec) {
-            spec_file_utils_1.walkSchema(spec, (obj) => {
-                UNNECESSARY_PROPS.forEach((key) => delete obj[key]);
+        });
+        function checkRef(targetRef) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [, components, group, name, ...rest] = targetRef.split('/');
+            spec_file_utils_1.walkSchema(spec[components][group][name], (obj) => {
+                if (obj.$ref) {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const [hash, components, group, name, ...rest] = obj.$ref.split('/');
+                    const ref = [hash, components, group, name].join('/');
+                    useRefs[ref] = true;
+                    checkRef(ref);
+                }
             });
-        }
-        deleteUnusedComponents(spec) {
-            const useRefs = {};
-            // pathから利用しているrefを取得
-            spec_file_utils_1.walkSchema(spec.paths, (obj) => {
-                if (obj.$ref)
-                    useRefs[obj.$ref] = true;
-            });
-            // pathで利用しているrefから芋づる式に利用しているrefを取得
-            lodash_1.default.each(useRefs, (_bool, ref) => checkRef(ref));
-            // ↑で取得した以外のcomponents情報を削除
-            lodash_1.default.each(spec.components, (schemas, key) => {
-                lodash_1.default.each(schemas, (_obj, name) => {
-                    const p = `#/components/${key}/${name}`;
-                    if (!useRefs[p])
-                        delete schemas[name];
-                });
-            });
-            function checkRef(targetRef) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const [, components, group, name, ...rest] = targetRef.split('/');
-                spec_file_utils_1.walkSchema(spec[components][group][name], (obj) => {
-                    if (obj.$ref) {
-                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                        const [hash, components, group, name, ...rest] = obj.$ref.split('/');
-                        const ref = [hash, components, group, name].join('/');
-                        useRefs[ref] = true;
-                        checkRef(ref);
-                    }
-                });
-            }
         }
     }
-    exports.default = JsSpecGenerator;
-});
+}
+exports.default = JsSpecGenerator;

--- a/dist/compiled/js_spec_generator.js
+++ b/dist/compiled/js_spec_generator.js
@@ -1,0 +1,87 @@
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "path", "lodash", "./utils", "./spec_file_utils"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    // @ts-nocheck
+    const path_1 = __importDefault(require("path"));
+    const lodash_1 = __importDefault(require("lodash"));
+    const utils_1 = require("./utils");
+    const spec_file_utils_1 = require("./spec_file_utils");
+    const UNNECESSARY_PROPS = [
+        spec_file_utils_1.ALTERNATIVE_REF_KEY,
+        'description',
+        'info',
+        spec_file_utils_1.MODEL_DEF_KEY,
+        'x-id-attribute',
+        'x-attribute-as',
+        'x-enum-key-attributes',
+    ];
+    class JsSpecGenerator {
+        constructor({ outputPath = '', templatePath, extension = 'js' }) {
+            this.outputPath = outputPath;
+            this.templatePath = templatePath;
+            this.templates = utils_1.readTemplates(['spec', 'head'], this.templatePath);
+            const { dir, name } = path_1.default.parse(this.outputPath);
+            this.outputDir = dir;
+            this.outputFileName = `${name}.${extension}`;
+            this.write = this.write.bind(this);
+        }
+        write(spec) {
+            this.deleteUnnecessaryProps(spec);
+            this.deleteUnusedComponents(spec);
+            const text = utils_1.render(this.templates.spec, {
+                spec: JSON.stringify(spec, null, 2),
+            }, {
+                head: this.templates.head,
+            });
+            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
+        }
+        deleteUnnecessaryProps(spec) {
+            spec_file_utils_1.walkSchema(spec, (obj) => {
+                UNNECESSARY_PROPS.forEach((key) => delete obj[key]);
+            });
+        }
+        deleteUnusedComponents(spec) {
+            const useRefs = {};
+            // pathから利用しているrefを取得
+            spec_file_utils_1.walkSchema(spec.paths, (obj) => {
+                if (obj.$ref)
+                    useRefs[obj.$ref] = true;
+            });
+            // pathで利用しているrefから芋づる式に利用しているrefを取得
+            lodash_1.default.each(useRefs, (_bool, ref) => checkRef(ref));
+            // ↑で取得した以外のcomponents情報を削除
+            lodash_1.default.each(spec.components, (schemas, key) => {
+                lodash_1.default.each(schemas, (_obj, name) => {
+                    const p = `#/components/${key}/${name}`;
+                    if (!useRefs[p])
+                        delete schemas[name];
+                });
+            });
+            function checkRef(targetRef) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const [, components, group, name, ...rest] = targetRef.split('/');
+                spec_file_utils_1.walkSchema(spec[components][group][name], (obj) => {
+                    if (obj.$ref) {
+                        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                        const [hash, components, group, name, ...rest] = obj.$ref.split('/');
+                        const ref = [hash, components, group, name].join('/');
+                        useRefs[ref] = true;
+                        checkRef(ref);
+                    }
+                });
+            }
+        }
+    }
+    module.exports = JsSpecGenerator;
+});

--- a/dist/compiled/js_spec_generator.js
+++ b/dist/compiled/js_spec_generator.js
@@ -83,5 +83,5 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             }
         }
     }
-    module.exports = JsSpecGenerator;
+    exports.default = JsSpecGenerator;
 });

--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -1,0 +1,360 @@
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "lodash", "path", "./utils"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    /* eslint-disable */
+    // @ts-nocheck
+    const lodash_1 = __importDefault(require("lodash"));
+    const path_1 = __importDefault(require("path"));
+    const utils_1 = require("./utils");
+    /**
+     * モデル定義からモデルファイルを作成
+     */
+    class ModelGenerator {
+        constructor({ outputDir = '', outputBaseDir = '', templatePath = {}, usePropType = false, useTypeScript = false, attributeConverter = (str) => str, definitions = {}, extension = 'js', }) {
+            this.outputDir = outputDir;
+            this.outputBaseDir = outputBaseDir;
+            this.templatePath = templatePath;
+            this.usePropType = usePropType;
+            this.useTypeScript = useTypeScript;
+            this.attributeConverter = attributeConverter;
+            this.definitions = definitions;
+            this.extension = extension;
+            this.templates = utils_1.readTemplates(['model', 'models', 'override', 'head', 'dependency', 'oneOf'], this.templatePath);
+            this.writeModel = this.writeModel.bind(this);
+            this.writeIndex = this.writeIndex.bind(this);
+            this._modelNameList = [];
+            this.importImmutableMap = false;
+        }
+        /**
+         * モデル定義ごとに呼び出し
+         * - モデルファイルを書き出す
+         * - Promiseでモデル名(Petなど)を返す
+         */
+        writeModel(model, name) {
+            const { properties } = model; // dereferenced
+            const fileName = lodash_1.default.snakeCase(name);
+            const idAttribute = utils_1.getIdAttribute(model, name);
+            if (!idAttribute)
+                return;
+            // requiredはモデル定義のものを使う
+            const required = this.definitions[name] && this.definitions[name].required;
+            if (this._modelNameList.includes(name))
+                return;
+            this._modelNameList.push(name);
+            return this._renderBaseModel(name, utils_1.applyRequired(properties, required), idAttribute).then(({ text, props }) => {
+                utils_1.writeFile(path_1.default.join(this.outputBaseDir, `${fileName}.${this.extension}`), text);
+                return this._writeOverrideModel(name, fileName, props).then(() => name);
+            });
+        }
+        writeIndex(modelNameList = this._modelNameList) {
+            const text = utils_1.render(this.templates.models, {
+                models: lodash_1.default.uniq(modelNameList).map((name) => ({ fileName: lodash_1.default.snakeCase(name), name })),
+            }, {
+                head: this.templates.head,
+            });
+            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, `index.${this.extension}`), text);
+        }
+        _writeOverrideModel(name, fileName, props) {
+            const overrideText = this._renderOverrideModel(name, fileName, props);
+            const filePath = path_1.default.join(this.outputDir, `${fileName}.${this.extension}`);
+            return utils_1.isFileExistPromise(filePath).then((isExist) => isExist || utils_1.writeFilePromise(filePath, overrideText));
+        }
+        _prepareImportList(importList) {
+            return lodash_1.default.uniqBy(importList, 'modelName').map(({ modelName, filePath }) => {
+                return {
+                    name: modelName,
+                    schemaName: utils_1.schemaName(modelName),
+                    filePath: filePath ? filePath : lodash_1.default.snakeCase(modelName),
+                };
+            });
+        }
+        _prepareIdAttribute(idAttribute) {
+            const splits = idAttribute.split('.');
+            if (splits[0] === 'parent') {
+                splits.shift();
+                return `(value, parent) => parent${splits
+                    .map((str) => `['${this.attributeConverter(str)}']`)
+                    .join('')}`;
+            }
+            if (splits.length === 1) {
+                return `'${this.attributeConverter(splits[0])}'`;
+            }
+            return `(value) => value${splits.map((str) => `['${this.attributeConverter(str)}']`).join('')}`;
+        }
+        _renderBaseModel(name, properties, idAttribute) {
+            return new Promise((resolve, reject) => {
+                const importList = [];
+                const oneOfs = [];
+                let oneOfsCounter = 1;
+                const dependencySchema = utils_1.parseSchema(properties, ({ type, value }) => {
+                    if (type === 'model') {
+                        const modelName = utils_1.getModelName(value);
+                        if (utils_1.getIdAttribute(value, modelName)) {
+                            importList.push({ modelName, value });
+                            return utils_1.schemaName(modelName);
+                        }
+                    }
+                    if (type === 'oneOf') {
+                        const key = `oneOfSchema${oneOfsCounter++}`;
+                        value.key = key;
+                        oneOfs.push(value);
+                        return key;
+                    }
+                });
+                // reset
+                this.importImmutableMap = false;
+                const props = {
+                    name,
+                    idAttribute: this._prepareIdAttribute(idAttribute),
+                    usePropTypes: this.usePropType,
+                    useTypeScript: this.useTypeScript,
+                    props: this._convertPropForTemplate(properties, dependencySchema),
+                    schema: utils_1.objectToTemplateValue(utils_1.changeFormat(dependencySchema, this.attributeConverter)),
+                    oneOfs: oneOfs.map((obj) => Object.assign(obj, {
+                        mapping: utils_1.objectToTemplateValue(obj.mapping),
+                        propertyName: this._prepareIdAttribute(obj.propertyName),
+                    })),
+                    importList: this._prepareImportList(importList),
+                    getPropTypes,
+                    getTypeScriptTypes,
+                    getDefaults,
+                    importImmutableMap: this.importImmutableMap,
+                };
+                const text = utils_1.render(this.templates.model, props, {
+                    head: this.templates.head,
+                    dependency: this.templates.dependency,
+                    oneOf: this.templates.oneOf,
+                });
+                // import先のモデルを書き出し
+                Promise.all(importList.map(({ value, modelName }) => this.writeModel(value, modelName))).then(() => resolve({ text, props }), // 自身の書き出しはここで実施
+                reject);
+            });
+        }
+        static get templatePropNames() {
+            return ['type', 'default', 'enum'];
+        }
+        _convertPropForTemplate(properties, dependencySchema = {}) {
+            return lodash_1.default.map(properties, (prop, name) => {
+                const base = {
+                    name: () => this.attributeConverter(name),
+                    type: this.generateTypeFrom(prop, dependencySchema[name]),
+                    alias: prop['x-attribute-as'],
+                    required: prop.required === true,
+                    isEnum: Boolean(prop.enum),
+                    isValueString: prop.type === 'string',
+                    propertyName: name,
+                    enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum, prop['x-enum-key-attributes']),
+                    enumType: this._getEnumTypes(prop.type),
+                    items: prop.items,
+                };
+                return this.constructor.templatePropNames.reduce((ret, key) => {
+                    ret[key] = ret[key] || properties[name][key];
+                    return ret;
+                }, base);
+            });
+        }
+        getEnumConstantName(enumName, propertyName) {
+            const convertedName = lodash_1.default.upperCase(propertyName)
+                .split(' ')
+                .join('_');
+            const convertedkey = lodash_1.default.upperCase(enumName)
+                .split(' ')
+                .join('_');
+            // enumNameがマイナスの数値の時
+            const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `MINUS_${convertedkey}` : convertedkey;
+            return `${convertedName}_${resolvedkey}`;
+        }
+        getEnumLiteralTypeName(enumName, propertyName) {
+            const convertedName = lodash_1.default.startCase(propertyName)
+                .split(' ')
+                .join('');
+            const convertedkey = lodash_1.default.startCase(enumName)
+                .split(' ')
+                .join('');
+            // enumNameがマイナスの数値の時
+            const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `Minus${convertedkey}` : convertedkey;
+            return `${convertedName}${resolvedkey}`;
+        }
+        getEnumObjects(name, enums, enumKeyAttributes = []) {
+            if (!enums)
+                return false;
+            return enums.map((current, index) => {
+                const enumName = enumKeyAttributes[index] || current;
+                return {
+                    name: this.getEnumConstantName(enumName, name),
+                    literalTypeName: this.getEnumLiteralTypeName(enumName, name),
+                    value: current,
+                };
+            });
+        }
+        _getEnumTypes(type) {
+            switch (type) {
+                case 'integer':
+                case 'number':
+                    return 'number';
+                default:
+                    return type;
+            }
+        }
+        generateTypeFrom(prop, definition) {
+            if (prop && prop.oneOf) {
+                const candidates = prop.oneOf.map((obj) => {
+                    const modelName = utils_1.getModelName(obj);
+                    return modelName ? { isModel: true, type: modelName } : { isModel: false, type: obj.type };
+                });
+                return {
+                    propType: `PropTypes.oneOfType([${lodash_1.default.uniq(candidates.map((c) => (c.isModel ? `${c.type}PropType` : _getPropTypes(c.type)))).join(', ')}])`,
+                    typeScript: lodash_1.default.uniq(candidates.map((c) => this._getEnumTypes(c.type))).join(' | '),
+                };
+            }
+            if (prop.type === 'array' && prop.items && prop.items.oneOf) {
+                const { propType, typeScript } = this.generateTypeFrom(prop.items, definition);
+                return {
+                    propType: `ImmutablePropTypes.listOf(${propType})`,
+                    typeScript: typeScript ? `List<(${typeScript})>` : '',
+                };
+            }
+            if (definition) {
+                return {
+                    propType: this._generatePropTypeFromDefinition(definition),
+                    typeScript: this._generateTypeScriptTypeFromDefinition(definition),
+                };
+            }
+            /* 上記の分岐でcomponentsに定義されている型の配列のパターンは吸収されるため、*/
+            /* ここではプリミティブ型の配列のパターンを扱う */
+            if (prop.type === 'array' && prop.items && prop.items.type) {
+                return {
+                    propType: `ImmutablePropTypes.listOf(${_getPropTypes(prop.items.type)})`,
+                    typeScript: `List<${this._getEnumTypes(prop.items.type)}>`,
+                };
+            }
+            if (prop.type === 'object' && prop.properties) {
+                if (!this.importImmutableMap)
+                    this.importImmutableMap = true;
+                const props = lodash_1.default.reduce(prop.properties, (acc, value, key) => {
+                    acc[this.attributeConverter(key)] = _getPropTypes(value.type, value.enum);
+                    return acc;
+                }, {});
+                return {
+                    propType: `ImmutablePropTypes.mapContains(${JSON.stringify(props).replace(/"/g, '')})`,
+                    typeScript: 'Map<any, any>',
+                };
+            }
+        }
+        _generatePropTypeFromDefinition(definition) {
+            let def;
+            if (lodash_1.default.isString(definition)) {
+                def = definition.replace(/Schema$/, '');
+                return `${def}PropType`;
+            }
+            if (lodash_1.default.isArray(definition)) {
+                def = definition[0];
+                const type = this._generatePropTypeFromDefinition(def);
+                return `ImmutablePropTypes.listOf(${type})`;
+            }
+            else if (lodash_1.default.isObject(definition)) {
+                const type = lodash_1.default.reduce(definition, (acc, value, key) => {
+                    acc[key] = this._generatePropTypeFromDefinition(value);
+                    return acc;
+                }, {});
+                return `ImmutablePropTypes.mapContains(${JSON.stringify(type).replace(/"/g, '')})`;
+            }
+        }
+        _generateTypeScriptTypeFromDefinition(definition) {
+            let def;
+            if (lodash_1.default.isString(definition)) {
+                return definition.replace(/Schema$/, '');
+            }
+            if (lodash_1.default.isArray(definition)) {
+                def = definition[0];
+                const type = this._generateTypeScriptTypeFromDefinition(def);
+                return `List<${type}>`;
+            }
+            else if (lodash_1.default.isObject(definition)) {
+                return 'Map<any, any>';
+            }
+        }
+        _renderOverrideModel(name, fileName, { props }) {
+            const enums = props
+                .filter((prop) => prop.enumObjects)
+                .reduce((acc, prop) => acc.concat(prop.enumObjects.reduce((acc, eo) => acc.concat(eo.name), [])), []);
+            return utils_1.render(this.templates.override, {
+                name,
+                fileName,
+                enums,
+                usePropTypes: this.usePropType,
+            }, {
+                head: this.templates.head,
+            });
+        }
+    }
+    function getPropTypes() {
+        return _getPropTypes(this.type, this.enum, this.enumObjects);
+    }
+    function _getPropTypes(type, enums, enumObjects) {
+        if (enumObjects) {
+            const nameMap = enumObjects.map((current) => current.name);
+            return `PropTypes.oneOf([${nameMap.join(', ')}])`;
+        }
+        else if (enums) {
+            return `PropTypes.oneOf([${enums.map((n) => (type === 'string' ? `'${n}'` : n)).join(', ')}])`;
+        }
+        switch (type) {
+            case 'integer':
+            case 'number':
+                return 'PropTypes.number';
+            case 'string':
+                return 'PropTypes.string';
+            case 'boolean':
+                return 'PropTypes.bool';
+            case 'array':
+                return 'PropTypes.array';
+            default:
+                return type && type.propType ? type.propType : 'PropTypes.any';
+        }
+    }
+    function getTypeScriptTypes() {
+        return _getTypeScriptTypes(this.type, this.enumObjects);
+    }
+    function _getTypeScriptTypes(type, enumObjects) {
+        if (enumObjects) {
+            const literalTypeNames = enumObjects.map((current) => current.literalTypeName);
+            return `${literalTypeNames.join(' | ')}`;
+        }
+        switch (type) {
+            case 'integer':
+            case 'number':
+                return 'number';
+            case 'string':
+                return 'string';
+            case 'boolean':
+                return 'boolean';
+            default:
+                return type && type.typeScript ? type.typeScript : 'any';
+        }
+    }
+    function getDefaults() {
+        if (lodash_1.default.isUndefined(this.default)) {
+            return 'undefined';
+        }
+        if (this.enumObjects) {
+            for (const enumObject of this.enumObjects) {
+                if (enumObject.value === this.default)
+                    return enumObject.name;
+            }
+        }
+        return this.type === 'string' ? `'${this.default}'` : this.default;
+    }
+    module.exports = ModelGenerator;
+});

--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -299,6 +299,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             });
         }
     }
+    exports.default = ModelGenerator;
     function getPropTypes() {
         return _getPropTypes(this.type, this.enum, this.enumObjects);
     }
@@ -356,5 +357,4 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
         }
         return this.type === 'string' ? `'${this.default}'` : this.default;
     }
-    module.exports = ModelGenerator;
 });

--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -1,360 +1,350 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+Object.defineProperty(exports, "__esModule", { value: true });
+/* eslint-disable */
+// @ts-nocheck
+const lodash_1 = __importDefault(require("lodash"));
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("./utils");
+/**
+ * モデル定義からモデルファイルを作成
+ */
+class ModelGenerator {
+    constructor({ outputDir = '', outputBaseDir = '', templatePath = {}, usePropType = false, useTypeScript = false, attributeConverter = (str) => str, definitions = {}, extension = 'js', }) {
+        this.outputDir = outputDir;
+        this.outputBaseDir = outputBaseDir;
+        this.templatePath = templatePath;
+        this.usePropType = usePropType;
+        this.useTypeScript = useTypeScript;
+        this.attributeConverter = attributeConverter;
+        this.definitions = definitions;
+        this.extension = extension;
+        this.templates = utils_1.readTemplates(['model', 'models', 'override', 'head', 'dependency', 'oneOf'], this.templatePath);
+        this.writeModel = this.writeModel.bind(this);
+        this.writeIndex = this.writeIndex.bind(this);
+        this._modelNameList = [];
+        this.importImmutableMap = false;
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "lodash", "path", "./utils"], factory);
-    }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    /* eslint-disable */
-    // @ts-nocheck
-    const lodash_1 = __importDefault(require("lodash"));
-    const path_1 = __importDefault(require("path"));
-    const utils_1 = require("./utils");
     /**
-     * モデル定義からモデルファイルを作成
+     * モデル定義ごとに呼び出し
+     * - モデルファイルを書き出す
+     * - Promiseでモデル名(Petなど)を返す
      */
-    class ModelGenerator {
-        constructor({ outputDir = '', outputBaseDir = '', templatePath = {}, usePropType = false, useTypeScript = false, attributeConverter = (str) => str, definitions = {}, extension = 'js', }) {
-            this.outputDir = outputDir;
-            this.outputBaseDir = outputBaseDir;
-            this.templatePath = templatePath;
-            this.usePropType = usePropType;
-            this.useTypeScript = useTypeScript;
-            this.attributeConverter = attributeConverter;
-            this.definitions = definitions;
-            this.extension = extension;
-            this.templates = utils_1.readTemplates(['model', 'models', 'override', 'head', 'dependency', 'oneOf'], this.templatePath);
-            this.writeModel = this.writeModel.bind(this);
-            this.writeIndex = this.writeIndex.bind(this);
-            this._modelNameList = [];
+    writeModel(model, name) {
+        const { properties } = model; // dereferenced
+        const fileName = lodash_1.default.snakeCase(name);
+        const idAttribute = utils_1.getIdAttribute(model, name);
+        if (!idAttribute)
+            return;
+        // requiredはモデル定義のものを使う
+        const required = this.definitions[name] && this.definitions[name].required;
+        if (this._modelNameList.includes(name))
+            return;
+        this._modelNameList.push(name);
+        return this._renderBaseModel(name, utils_1.applyRequired(properties, required), idAttribute).then(({ text, props }) => {
+            utils_1.writeFile(path_1.default.join(this.outputBaseDir, `${fileName}.${this.extension}`), text);
+            return this._writeOverrideModel(name, fileName, props).then(() => name);
+        });
+    }
+    writeIndex(modelNameList = this._modelNameList) {
+        const text = utils_1.render(this.templates.models, {
+            models: lodash_1.default.uniq(modelNameList).map((name) => ({ fileName: lodash_1.default.snakeCase(name), name })),
+        }, {
+            head: this.templates.head,
+        });
+        return utils_1.writeFilePromise(path_1.default.join(this.outputDir, `index.${this.extension}`), text);
+    }
+    _writeOverrideModel(name, fileName, props) {
+        const overrideText = this._renderOverrideModel(name, fileName, props);
+        const filePath = path_1.default.join(this.outputDir, `${fileName}.${this.extension}`);
+        return utils_1.isFileExistPromise(filePath).then((isExist) => isExist || utils_1.writeFilePromise(filePath, overrideText));
+    }
+    _prepareImportList(importList) {
+        return lodash_1.default.uniqBy(importList, 'modelName').map(({ modelName, filePath }) => {
+            return {
+                name: modelName,
+                schemaName: utils_1.schemaName(modelName),
+                filePath: filePath ? filePath : lodash_1.default.snakeCase(modelName),
+            };
+        });
+    }
+    _prepareIdAttribute(idAttribute) {
+        const splits = idAttribute.split('.');
+        if (splits[0] === 'parent') {
+            splits.shift();
+            return `(value, parent) => parent${splits
+                .map((str) => `['${this.attributeConverter(str)}']`)
+                .join('')}`;
+        }
+        if (splits.length === 1) {
+            return `'${this.attributeConverter(splits[0])}'`;
+        }
+        return `(value) => value${splits.map((str) => `['${this.attributeConverter(str)}']`).join('')}`;
+    }
+    _renderBaseModel(name, properties, idAttribute) {
+        return new Promise((resolve, reject) => {
+            const importList = [];
+            const oneOfs = [];
+            let oneOfsCounter = 1;
+            const dependencySchema = utils_1.parseSchema(properties, ({ type, value }) => {
+                if (type === 'model') {
+                    const modelName = utils_1.getModelName(value);
+                    if (utils_1.getIdAttribute(value, modelName)) {
+                        importList.push({ modelName, value });
+                        return utils_1.schemaName(modelName);
+                    }
+                }
+                if (type === 'oneOf') {
+                    const key = `oneOfSchema${oneOfsCounter++}`;
+                    value.key = key;
+                    oneOfs.push(value);
+                    return key;
+                }
+            });
+            // reset
             this.importImmutableMap = false;
-        }
-        /**
-         * モデル定義ごとに呼び出し
-         * - モデルファイルを書き出す
-         * - Promiseでモデル名(Petなど)を返す
-         */
-        writeModel(model, name) {
-            const { properties } = model; // dereferenced
-            const fileName = lodash_1.default.snakeCase(name);
-            const idAttribute = utils_1.getIdAttribute(model, name);
-            if (!idAttribute)
-                return;
-            // requiredはモデル定義のものを使う
-            const required = this.definitions[name] && this.definitions[name].required;
-            if (this._modelNameList.includes(name))
-                return;
-            this._modelNameList.push(name);
-            return this._renderBaseModel(name, utils_1.applyRequired(properties, required), idAttribute).then(({ text, props }) => {
-                utils_1.writeFile(path_1.default.join(this.outputBaseDir, `${fileName}.${this.extension}`), text);
-                return this._writeOverrideModel(name, fileName, props).then(() => name);
-            });
-        }
-        writeIndex(modelNameList = this._modelNameList) {
-            const text = utils_1.render(this.templates.models, {
-                models: lodash_1.default.uniq(modelNameList).map((name) => ({ fileName: lodash_1.default.snakeCase(name), name })),
-            }, {
-                head: this.templates.head,
-            });
-            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, `index.${this.extension}`), text);
-        }
-        _writeOverrideModel(name, fileName, props) {
-            const overrideText = this._renderOverrideModel(name, fileName, props);
-            const filePath = path_1.default.join(this.outputDir, `${fileName}.${this.extension}`);
-            return utils_1.isFileExistPromise(filePath).then((isExist) => isExist || utils_1.writeFilePromise(filePath, overrideText));
-        }
-        _prepareImportList(importList) {
-            return lodash_1.default.uniqBy(importList, 'modelName').map(({ modelName, filePath }) => {
-                return {
-                    name: modelName,
-                    schemaName: utils_1.schemaName(modelName),
-                    filePath: filePath ? filePath : lodash_1.default.snakeCase(modelName),
-                };
-            });
-        }
-        _prepareIdAttribute(idAttribute) {
-            const splits = idAttribute.split('.');
-            if (splits[0] === 'parent') {
-                splits.shift();
-                return `(value, parent) => parent${splits
-                    .map((str) => `['${this.attributeConverter(str)}']`)
-                    .join('')}`;
-            }
-            if (splits.length === 1) {
-                return `'${this.attributeConverter(splits[0])}'`;
-            }
-            return `(value) => value${splits.map((str) => `['${this.attributeConverter(str)}']`).join('')}`;
-        }
-        _renderBaseModel(name, properties, idAttribute) {
-            return new Promise((resolve, reject) => {
-                const importList = [];
-                const oneOfs = [];
-                let oneOfsCounter = 1;
-                const dependencySchema = utils_1.parseSchema(properties, ({ type, value }) => {
-                    if (type === 'model') {
-                        const modelName = utils_1.getModelName(value);
-                        if (utils_1.getIdAttribute(value, modelName)) {
-                            importList.push({ modelName, value });
-                            return utils_1.schemaName(modelName);
-                        }
-                    }
-                    if (type === 'oneOf') {
-                        const key = `oneOfSchema${oneOfsCounter++}`;
-                        value.key = key;
-                        oneOfs.push(value);
-                        return key;
-                    }
-                });
-                // reset
-                this.importImmutableMap = false;
-                const props = {
-                    name,
-                    idAttribute: this._prepareIdAttribute(idAttribute),
-                    usePropTypes: this.usePropType,
-                    useTypeScript: this.useTypeScript,
-                    props: this._convertPropForTemplate(properties, dependencySchema),
-                    schema: utils_1.objectToTemplateValue(utils_1.changeFormat(dependencySchema, this.attributeConverter)),
-                    oneOfs: oneOfs.map((obj) => Object.assign(obj, {
-                        mapping: utils_1.objectToTemplateValue(obj.mapping),
-                        propertyName: this._prepareIdAttribute(obj.propertyName),
-                    })),
-                    importList: this._prepareImportList(importList),
-                    getPropTypes,
-                    getTypeScriptTypes,
-                    getDefaults,
-                    importImmutableMap: this.importImmutableMap,
-                };
-                const text = utils_1.render(this.templates.model, props, {
-                    head: this.templates.head,
-                    dependency: this.templates.dependency,
-                    oneOf: this.templates.oneOf,
-                });
-                // import先のモデルを書き出し
-                Promise.all(importList.map(({ value, modelName }) => this.writeModel(value, modelName))).then(() => resolve({ text, props }), // 自身の書き出しはここで実施
-                reject);
-            });
-        }
-        static get templatePropNames() {
-            return ['type', 'default', 'enum'];
-        }
-        _convertPropForTemplate(properties, dependencySchema = {}) {
-            return lodash_1.default.map(properties, (prop, name) => {
-                const base = {
-                    name: () => this.attributeConverter(name),
-                    type: this.generateTypeFrom(prop, dependencySchema[name]),
-                    alias: prop['x-attribute-as'],
-                    required: prop.required === true,
-                    isEnum: Boolean(prop.enum),
-                    isValueString: prop.type === 'string',
-                    propertyName: name,
-                    enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum, prop['x-enum-key-attributes']),
-                    enumType: this._getEnumTypes(prop.type),
-                    items: prop.items,
-                };
-                return this.constructor.templatePropNames.reduce((ret, key) => {
-                    ret[key] = ret[key] || properties[name][key];
-                    return ret;
-                }, base);
-            });
-        }
-        getEnumConstantName(enumName, propertyName) {
-            const convertedName = lodash_1.default.upperCase(propertyName)
-                .split(' ')
-                .join('_');
-            const convertedkey = lodash_1.default.upperCase(enumName)
-                .split(' ')
-                .join('_');
-            // enumNameがマイナスの数値の時
-            const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `MINUS_${convertedkey}` : convertedkey;
-            return `${convertedName}_${resolvedkey}`;
-        }
-        getEnumLiteralTypeName(enumName, propertyName) {
-            const convertedName = lodash_1.default.startCase(propertyName)
-                .split(' ')
-                .join('');
-            const convertedkey = lodash_1.default.startCase(enumName)
-                .split(' ')
-                .join('');
-            // enumNameがマイナスの数値の時
-            const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `Minus${convertedkey}` : convertedkey;
-            return `${convertedName}${resolvedkey}`;
-        }
-        getEnumObjects(name, enums, enumKeyAttributes = []) {
-            if (!enums)
-                return false;
-            return enums.map((current, index) => {
-                const enumName = enumKeyAttributes[index] || current;
-                return {
-                    name: this.getEnumConstantName(enumName, name),
-                    literalTypeName: this.getEnumLiteralTypeName(enumName, name),
-                    value: current,
-                };
-            });
-        }
-        _getEnumTypes(type) {
-            switch (type) {
-                case 'integer':
-                case 'number':
-                    return 'number';
-                default:
-                    return type;
-            }
-        }
-        generateTypeFrom(prop, definition) {
-            if (prop && prop.oneOf) {
-                const candidates = prop.oneOf.map((obj) => {
-                    const modelName = utils_1.getModelName(obj);
-                    return modelName ? { isModel: true, type: modelName } : { isModel: false, type: obj.type };
-                });
-                return {
-                    propType: `PropTypes.oneOfType([${lodash_1.default.uniq(candidates.map((c) => (c.isModel ? `${c.type}PropType` : _getPropTypes(c.type)))).join(', ')}])`,
-                    typeScript: lodash_1.default.uniq(candidates.map((c) => this._getEnumTypes(c.type))).join(' | '),
-                };
-            }
-            if (prop.type === 'array' && prop.items && prop.items.oneOf) {
-                const { propType, typeScript } = this.generateTypeFrom(prop.items, definition);
-                return {
-                    propType: `ImmutablePropTypes.listOf(${propType})`,
-                    typeScript: typeScript ? `List<(${typeScript})>` : '',
-                };
-            }
-            if (definition) {
-                return {
-                    propType: this._generatePropTypeFromDefinition(definition),
-                    typeScript: this._generateTypeScriptTypeFromDefinition(definition),
-                };
-            }
-            /* 上記の分岐でcomponentsに定義されている型の配列のパターンは吸収されるため、*/
-            /* ここではプリミティブ型の配列のパターンを扱う */
-            if (prop.type === 'array' && prop.items && prop.items.type) {
-                return {
-                    propType: `ImmutablePropTypes.listOf(${_getPropTypes(prop.items.type)})`,
-                    typeScript: `List<${this._getEnumTypes(prop.items.type)}>`,
-                };
-            }
-            if (prop.type === 'object' && prop.properties) {
-                if (!this.importImmutableMap)
-                    this.importImmutableMap = true;
-                const props = lodash_1.default.reduce(prop.properties, (acc, value, key) => {
-                    acc[this.attributeConverter(key)] = _getPropTypes(value.type, value.enum);
-                    return acc;
-                }, {});
-                return {
-                    propType: `ImmutablePropTypes.mapContains(${JSON.stringify(props).replace(/"/g, '')})`,
-                    typeScript: 'Map<any, any>',
-                };
-            }
-        }
-        _generatePropTypeFromDefinition(definition) {
-            let def;
-            if (lodash_1.default.isString(definition)) {
-                def = definition.replace(/Schema$/, '');
-                return `${def}PropType`;
-            }
-            if (lodash_1.default.isArray(definition)) {
-                def = definition[0];
-                const type = this._generatePropTypeFromDefinition(def);
-                return `ImmutablePropTypes.listOf(${type})`;
-            }
-            else if (lodash_1.default.isObject(definition)) {
-                const type = lodash_1.default.reduce(definition, (acc, value, key) => {
-                    acc[key] = this._generatePropTypeFromDefinition(value);
-                    return acc;
-                }, {});
-                return `ImmutablePropTypes.mapContains(${JSON.stringify(type).replace(/"/g, '')})`;
-            }
-        }
-        _generateTypeScriptTypeFromDefinition(definition) {
-            let def;
-            if (lodash_1.default.isString(definition)) {
-                return definition.replace(/Schema$/, '');
-            }
-            if (lodash_1.default.isArray(definition)) {
-                def = definition[0];
-                const type = this._generateTypeScriptTypeFromDefinition(def);
-                return `List<${type}>`;
-            }
-            else if (lodash_1.default.isObject(definition)) {
-                return 'Map<any, any>';
-            }
-        }
-        _renderOverrideModel(name, fileName, { props }) {
-            const enums = props
-                .filter((prop) => prop.enumObjects)
-                .reduce((acc, prop) => acc.concat(prop.enumObjects.reduce((acc, eo) => acc.concat(eo.name), [])), []);
-            return utils_1.render(this.templates.override, {
+            const props = {
                 name,
-                fileName,
-                enums,
+                idAttribute: this._prepareIdAttribute(idAttribute),
                 usePropTypes: this.usePropType,
-            }, {
+                useTypeScript: this.useTypeScript,
+                props: this._convertPropForTemplate(properties, dependencySchema),
+                schema: utils_1.objectToTemplateValue(utils_1.changeFormat(dependencySchema, this.attributeConverter)),
+                oneOfs: oneOfs.map((obj) => Object.assign(obj, {
+                    mapping: utils_1.objectToTemplateValue(obj.mapping),
+                    propertyName: this._prepareIdAttribute(obj.propertyName),
+                })),
+                importList: this._prepareImportList(importList),
+                getPropTypes,
+                getTypeScriptTypes,
+                getDefaults,
+                importImmutableMap: this.importImmutableMap,
+            };
+            const text = utils_1.render(this.templates.model, props, {
                 head: this.templates.head,
+                dependency: this.templates.dependency,
+                oneOf: this.templates.oneOf,
             });
-        }
+            // import先のモデルを書き出し
+            Promise.all(importList.map(({ value, modelName }) => this.writeModel(value, modelName))).then(() => resolve({ text, props }), // 自身の書き出しはここで実施
+            reject);
+        });
     }
-    exports.default = ModelGenerator;
-    function getPropTypes() {
-        return _getPropTypes(this.type, this.enum, this.enumObjects);
+    static get templatePropNames() {
+        return ['type', 'default', 'enum'];
     }
-    function _getPropTypes(type, enums, enumObjects) {
-        if (enumObjects) {
-            const nameMap = enumObjects.map((current) => current.name);
-            return `PropTypes.oneOf([${nameMap.join(', ')}])`;
-        }
-        else if (enums) {
-            return `PropTypes.oneOf([${enums.map((n) => (type === 'string' ? `'${n}'` : n)).join(', ')}])`;
-        }
-        switch (type) {
-            case 'integer':
-            case 'number':
-                return 'PropTypes.number';
-            case 'string':
-                return 'PropTypes.string';
-            case 'boolean':
-                return 'PropTypes.bool';
-            case 'array':
-                return 'PropTypes.array';
-            default:
-                return type && type.propType ? type.propType : 'PropTypes.any';
-        }
+    _convertPropForTemplate(properties, dependencySchema = {}) {
+        return lodash_1.default.map(properties, (prop, name) => {
+            const base = {
+                name: () => this.attributeConverter(name),
+                type: this.generateTypeFrom(prop, dependencySchema[name]),
+                alias: prop['x-attribute-as'],
+                required: prop.required === true,
+                isEnum: Boolean(prop.enum),
+                isValueString: prop.type === 'string',
+                propertyName: name,
+                enumObjects: this.getEnumObjects(this.attributeConverter(name), prop.enum, prop['x-enum-key-attributes']),
+                enumType: this._getEnumTypes(prop.type),
+                items: prop.items,
+            };
+            return this.constructor.templatePropNames.reduce((ret, key) => {
+                ret[key] = ret[key] || properties[name][key];
+                return ret;
+            }, base);
+        });
     }
-    function getTypeScriptTypes() {
-        return _getTypeScriptTypes(this.type, this.enumObjects);
+    getEnumConstantName(enumName, propertyName) {
+        const convertedName = lodash_1.default.upperCase(propertyName)
+            .split(' ')
+            .join('_');
+        const convertedkey = lodash_1.default.upperCase(enumName)
+            .split(' ')
+            .join('_');
+        // enumNameがマイナスの数値の時
+        const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `MINUS_${convertedkey}` : convertedkey;
+        return `${convertedName}_${resolvedkey}`;
     }
-    function _getTypeScriptTypes(type, enumObjects) {
-        if (enumObjects) {
-            const literalTypeNames = enumObjects.map((current) => current.literalTypeName);
-            return `${literalTypeNames.join(' | ')}`;
-        }
+    getEnumLiteralTypeName(enumName, propertyName) {
+        const convertedName = lodash_1.default.startCase(propertyName)
+            .split(' ')
+            .join('');
+        const convertedkey = lodash_1.default.startCase(enumName)
+            .split(' ')
+            .join('');
+        // enumNameがマイナスの数値の時
+        const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `Minus${convertedkey}` : convertedkey;
+        return `${convertedName}${resolvedkey}`;
+    }
+    getEnumObjects(name, enums, enumKeyAttributes = []) {
+        if (!enums)
+            return false;
+        return enums.map((current, index) => {
+            const enumName = enumKeyAttributes[index] || current;
+            return {
+                name: this.getEnumConstantName(enumName, name),
+                literalTypeName: this.getEnumLiteralTypeName(enumName, name),
+                value: current,
+            };
+        });
+    }
+    _getEnumTypes(type) {
         switch (type) {
             case 'integer':
             case 'number':
                 return 'number';
-            case 'string':
-                return 'string';
-            case 'boolean':
-                return 'boolean';
             default:
-                return type && type.typeScript ? type.typeScript : 'any';
+                return type;
         }
     }
-    function getDefaults() {
-        if (lodash_1.default.isUndefined(this.default)) {
-            return 'undefined';
+    generateTypeFrom(prop, definition) {
+        if (prop && prop.oneOf) {
+            const candidates = prop.oneOf.map((obj) => {
+                const modelName = utils_1.getModelName(obj);
+                return modelName ? { isModel: true, type: modelName } : { isModel: false, type: obj.type };
+            });
+            return {
+                propType: `PropTypes.oneOfType([${lodash_1.default.uniq(candidates.map((c) => (c.isModel ? `${c.type}PropType` : _getPropTypes(c.type)))).join(', ')}])`,
+                typeScript: lodash_1.default.uniq(candidates.map((c) => this._getEnumTypes(c.type))).join(' | '),
+            };
         }
-        if (this.enumObjects) {
-            for (const enumObject of this.enumObjects) {
-                if (enumObject.value === this.default)
-                    return enumObject.name;
-            }
+        if (prop.type === 'array' && prop.items && prop.items.oneOf) {
+            const { propType, typeScript } = this.generateTypeFrom(prop.items, definition);
+            return {
+                propType: `ImmutablePropTypes.listOf(${propType})`,
+                typeScript: typeScript ? `List<(${typeScript})>` : '',
+            };
         }
-        return this.type === 'string' ? `'${this.default}'` : this.default;
+        if (definition) {
+            return {
+                propType: this._generatePropTypeFromDefinition(definition),
+                typeScript: this._generateTypeScriptTypeFromDefinition(definition),
+            };
+        }
+        /* 上記の分岐でcomponentsに定義されている型の配列のパターンは吸収されるため、*/
+        /* ここではプリミティブ型の配列のパターンを扱う */
+        if (prop.type === 'array' && prop.items && prop.items.type) {
+            return {
+                propType: `ImmutablePropTypes.listOf(${_getPropTypes(prop.items.type)})`,
+                typeScript: `List<${this._getEnumTypes(prop.items.type)}>`,
+            };
+        }
+        if (prop.type === 'object' && prop.properties) {
+            if (!this.importImmutableMap)
+                this.importImmutableMap = true;
+            const props = lodash_1.default.reduce(prop.properties, (acc, value, key) => {
+                acc[this.attributeConverter(key)] = _getPropTypes(value.type, value.enum);
+                return acc;
+            }, {});
+            return {
+                propType: `ImmutablePropTypes.mapContains(${JSON.stringify(props).replace(/"/g, '')})`,
+                typeScript: 'Map<any, any>',
+            };
+        }
     }
-});
+    _generatePropTypeFromDefinition(definition) {
+        let def;
+        if (lodash_1.default.isString(definition)) {
+            def = definition.replace(/Schema$/, '');
+            return `${def}PropType`;
+        }
+        if (lodash_1.default.isArray(definition)) {
+            def = definition[0];
+            const type = this._generatePropTypeFromDefinition(def);
+            return `ImmutablePropTypes.listOf(${type})`;
+        }
+        else if (lodash_1.default.isObject(definition)) {
+            const type = lodash_1.default.reduce(definition, (acc, value, key) => {
+                acc[key] = this._generatePropTypeFromDefinition(value);
+                return acc;
+            }, {});
+            return `ImmutablePropTypes.mapContains(${JSON.stringify(type).replace(/"/g, '')})`;
+        }
+    }
+    _generateTypeScriptTypeFromDefinition(definition) {
+        let def;
+        if (lodash_1.default.isString(definition)) {
+            return definition.replace(/Schema$/, '');
+        }
+        if (lodash_1.default.isArray(definition)) {
+            def = definition[0];
+            const type = this._generateTypeScriptTypeFromDefinition(def);
+            return `List<${type}>`;
+        }
+        else if (lodash_1.default.isObject(definition)) {
+            return 'Map<any, any>';
+        }
+    }
+    _renderOverrideModel(name, fileName, { props }) {
+        const enums = props
+            .filter((prop) => prop.enumObjects)
+            .reduce((acc, prop) => acc.concat(prop.enumObjects.reduce((acc, eo) => acc.concat(eo.name), [])), []);
+        return utils_1.render(this.templates.override, {
+            name,
+            fileName,
+            enums,
+            usePropTypes: this.usePropType,
+        }, {
+            head: this.templates.head,
+        });
+    }
+}
+exports.default = ModelGenerator;
+function getPropTypes() {
+    return _getPropTypes(this.type, this.enum, this.enumObjects);
+}
+function _getPropTypes(type, enums, enumObjects) {
+    if (enumObjects) {
+        const nameMap = enumObjects.map((current) => current.name);
+        return `PropTypes.oneOf([${nameMap.join(', ')}])`;
+    }
+    else if (enums) {
+        return `PropTypes.oneOf([${enums.map((n) => (type === 'string' ? `'${n}'` : n)).join(', ')}])`;
+    }
+    switch (type) {
+        case 'integer':
+        case 'number':
+            return 'PropTypes.number';
+        case 'string':
+            return 'PropTypes.string';
+        case 'boolean':
+            return 'PropTypes.bool';
+        case 'array':
+            return 'PropTypes.array';
+        default:
+            return type && type.propType ? type.propType : 'PropTypes.any';
+    }
+}
+function getTypeScriptTypes() {
+    return _getTypeScriptTypes(this.type, this.enumObjects);
+}
+function _getTypeScriptTypes(type, enumObjects) {
+    if (enumObjects) {
+        const literalTypeNames = enumObjects.map((current) => current.literalTypeName);
+        return `${literalTypeNames.join(' | ')}`;
+    }
+    switch (type) {
+        case 'integer':
+        case 'number':
+            return 'number';
+        case 'string':
+            return 'string';
+        case 'boolean':
+            return 'boolean';
+        default:
+            return type && type.typeScript ? type.typeScript : 'any';
+    }
+}
+function getDefaults() {
+    if (lodash_1.default.isUndefined(this.default)) {
+        return 'undefined';
+    }
+    if (this.enumObjects) {
+        for (const enumObject of this.enumObjects) {
+            if (enumObject.value === this.default)
+                return enumObject.name;
+        }
+    }
+    return this.type === 'string' ? `'${this.default}'` : this.default;
+}

--- a/dist/compiled/schema_generator.js
+++ b/dist/compiled/schema_generator.js
@@ -1,0 +1,128 @@
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "lodash", "path", "./utils"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    // @ts-nocheck
+    const lodash_1 = __importDefault(require("lodash"));
+    const path_1 = __importDefault(require("path"));
+    const utils_1 = require("./utils");
+    /**
+     * レスポンス定義からnormalizr用のschemaを作成
+     * content-typeはjsonのみサポート
+     */
+    class SchemaGenerator {
+        constructor({ outputPath = '', templatePath = {}, modelGenerator, modelsDir, attributeConverter = (str) => str, useTypeScript, extension = 'js', }) {
+            this.outputPath = outputPath;
+            const { dir, name } = path_1.default.parse(this.outputPath);
+            this.outputDir = dir;
+            this.outputFileName = `${name}.${extension}`;
+            this.templatePath = templatePath;
+            this.modelGenerator = modelGenerator;
+            this.modelsDir = modelsDir;
+            this.attributeConverter = attributeConverter;
+            this.templates = utils_1.readTemplates(['schema', 'head', 'oneOf'], this.templatePath);
+            this.parsedObjects = {};
+            this._importModels = [];
+            this.oneOfs = [];
+            this.parse = this.parse.bind(this);
+            this.write = this.write.bind(this);
+            this.useTypeScript = useTypeScript;
+        }
+        /**
+         * API(id)ごとのスキーマをパース
+         * - 内部でモデル情報をメモ
+         */
+        parse(id, responses) {
+            lodash_1.default.each(responses, (response, code) => {
+                const contents = SchemaGenerator.getJsonContents(response);
+                if (!contents) {
+                    console.warn(`${id}:${code} does not have content.`); // eslint-disable-line no-console
+                    return;
+                }
+                const onSchema = ({ type, value }) => {
+                    if (type === 'model') {
+                        const modelName = utils_1.getModelName(value);
+                        if (utils_1.getIdAttribute(value, modelName)) {
+                            this._importModels.push({
+                                modelName,
+                                model: value,
+                            });
+                            return utils_1.schemaName(modelName);
+                        }
+                    }
+                    if (type === 'oneOf') {
+                        const count = this.oneOfs.length + 1;
+                        const key = `oneOfSchema${count}`;
+                        value.key = key;
+                        this.oneOfs.push(value);
+                        return key;
+                    }
+                };
+                utils_1.applyIf(utils_1.parseSchema(contents.schema, onSchema), (val) => {
+                    this.parsedObjects[id] = this.parsedObjects[id] || {};
+                    this.parsedObjects[id][code] = val;
+                });
+            });
+        }
+        /**
+         * パース情報とテンプレートからschema.jsとmodels/index.js書き出し
+         */
+        write() {
+            return Promise.all([
+                this._writeSchemaFile(),
+                this.importModels.map(({ modelName, model }) => this.modelGenerator.writeModel(model, modelName)),
+            ]).then(() => {
+                this.modelGenerator.writeIndex();
+            });
+        }
+        _writeSchemaFile() {
+            const oneOfs = this.oneOfs.map((obj) => Object.assign(obj, {
+                mapping: utils_1.objectToTemplateValue(obj.mapping),
+                propertyName: `'${this.attributeConverter(obj.propertyName)}'`,
+            }));
+            const text = utils_1.render(this.templates.schema, {
+                importList: this._prepareImportList(),
+                data: utils_1.objectToTemplateValue(this.formattedSchema),
+                hasOneOf: oneOfs.length > 0,
+                oneOfs,
+                useTypeScript: this.useTypeScript,
+            }, {
+                head: this.templates.head,
+                oneOf: this.templates.oneOf,
+            });
+            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
+        }
+        _prepareImportList() {
+            const relative = path_1.default.relative(this.outputDir, this.modelsDir);
+            return this.importModels.map(({ modelName }) => {
+                return {
+                    name: utils_1.schemaName(modelName),
+                    path: path_1.default.join(relative, lodash_1.default.snakeCase(modelName)),
+                };
+            });
+        }
+        get importModels() {
+            return lodash_1.default.uniqBy(this._importModels, 'modelName');
+        }
+        get formattedSchema() {
+            return lodash_1.default.reduce(this.parsedObjects, (acc, schema, key) => {
+                acc[key] = utils_1.changeFormat(schema, this.attributeConverter);
+                return acc;
+            }, {});
+        }
+        static getJsonContents(response) {
+            return response.content && response.content['application/json'];
+        }
+    }
+    module.exports = SchemaGenerator;
+});

--- a/dist/compiled/schema_generator.js
+++ b/dist/compiled/schema_generator.js
@@ -1,128 +1,118 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+Object.defineProperty(exports, "__esModule", { value: true });
+// @ts-nocheck
+const lodash_1 = __importDefault(require("lodash"));
+const path_1 = __importDefault(require("path"));
+const utils_1 = require("./utils");
+/**
+ * レスポンス定義からnormalizr用のschemaを作成
+ * content-typeはjsonのみサポート
+ */
+class SchemaGenerator {
+    constructor({ outputPath = '', templatePath = {}, modelGenerator, modelsDir, attributeConverter = (str) => str, useTypeScript, extension = 'js', }) {
+        this.outputPath = outputPath;
+        const { dir, name } = path_1.default.parse(this.outputPath);
+        this.outputDir = dir;
+        this.outputFileName = `${name}.${extension}`;
+        this.templatePath = templatePath;
+        this.modelGenerator = modelGenerator;
+        this.modelsDir = modelsDir;
+        this.attributeConverter = attributeConverter;
+        this.templates = utils_1.readTemplates(['schema', 'head', 'oneOf'], this.templatePath);
+        this.parsedObjects = {};
+        this._importModels = [];
+        this.oneOfs = [];
+        this.parse = this.parse.bind(this);
+        this.write = this.write.bind(this);
+        this.useTypeScript = useTypeScript;
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "lodash", "path", "./utils"], factory);
-    }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    // @ts-nocheck
-    const lodash_1 = __importDefault(require("lodash"));
-    const path_1 = __importDefault(require("path"));
-    const utils_1 = require("./utils");
     /**
-     * レスポンス定義からnormalizr用のschemaを作成
-     * content-typeはjsonのみサポート
+     * API(id)ごとのスキーマをパース
+     * - 内部でモデル情報をメモ
      */
-    class SchemaGenerator {
-        constructor({ outputPath = '', templatePath = {}, modelGenerator, modelsDir, attributeConverter = (str) => str, useTypeScript, extension = 'js', }) {
-            this.outputPath = outputPath;
-            const { dir, name } = path_1.default.parse(this.outputPath);
-            this.outputDir = dir;
-            this.outputFileName = `${name}.${extension}`;
-            this.templatePath = templatePath;
-            this.modelGenerator = modelGenerator;
-            this.modelsDir = modelsDir;
-            this.attributeConverter = attributeConverter;
-            this.templates = utils_1.readTemplates(['schema', 'head', 'oneOf'], this.templatePath);
-            this.parsedObjects = {};
-            this._importModels = [];
-            this.oneOfs = [];
-            this.parse = this.parse.bind(this);
-            this.write = this.write.bind(this);
-            this.useTypeScript = useTypeScript;
-        }
-        /**
-         * API(id)ごとのスキーマをパース
-         * - 内部でモデル情報をメモ
-         */
-        parse(id, responses) {
-            lodash_1.default.each(responses, (response, code) => {
-                const contents = SchemaGenerator.getJsonContents(response);
-                if (!contents) {
-                    console.warn(`${id}:${code} does not have content.`); // eslint-disable-line no-console
-                    return;
+    parse(id, responses) {
+        lodash_1.default.each(responses, (response, code) => {
+            const contents = SchemaGenerator.getJsonContents(response);
+            if (!contents) {
+                console.warn(`${id}:${code} does not have content.`); // eslint-disable-line no-console
+                return;
+            }
+            const onSchema = ({ type, value }) => {
+                if (type === 'model') {
+                    const modelName = utils_1.getModelName(value);
+                    if (utils_1.getIdAttribute(value, modelName)) {
+                        this._importModels.push({
+                            modelName,
+                            model: value,
+                        });
+                        return utils_1.schemaName(modelName);
+                    }
                 }
-                const onSchema = ({ type, value }) => {
-                    if (type === 'model') {
-                        const modelName = utils_1.getModelName(value);
-                        if (utils_1.getIdAttribute(value, modelName)) {
-                            this._importModels.push({
-                                modelName,
-                                model: value,
-                            });
-                            return utils_1.schemaName(modelName);
-                        }
-                    }
-                    if (type === 'oneOf') {
-                        const count = this.oneOfs.length + 1;
-                        const key = `oneOfSchema${count}`;
-                        value.key = key;
-                        this.oneOfs.push(value);
-                        return key;
-                    }
-                };
-                utils_1.applyIf(utils_1.parseSchema(contents.schema, onSchema), (val) => {
-                    this.parsedObjects[id] = this.parsedObjects[id] || {};
-                    this.parsedObjects[id][code] = val;
-                });
+                if (type === 'oneOf') {
+                    const count = this.oneOfs.length + 1;
+                    const key = `oneOfSchema${count}`;
+                    value.key = key;
+                    this.oneOfs.push(value);
+                    return key;
+                }
+            };
+            utils_1.applyIf(utils_1.parseSchema(contents.schema, onSchema), (val) => {
+                this.parsedObjects[id] = this.parsedObjects[id] || {};
+                this.parsedObjects[id][code] = val;
             });
-        }
-        /**
-         * パース情報とテンプレートからschema.jsとmodels/index.js書き出し
-         */
-        write() {
-            return Promise.all([
-                this._writeSchemaFile(),
-                this.importModels.map(({ modelName, model }) => this.modelGenerator.writeModel(model, modelName)),
-            ]).then(() => {
-                this.modelGenerator.writeIndex();
-            });
-        }
-        _writeSchemaFile() {
-            const oneOfs = this.oneOfs.map((obj) => Object.assign(obj, {
-                mapping: utils_1.objectToTemplateValue(obj.mapping),
-                propertyName: `'${this.attributeConverter(obj.propertyName)}'`,
-            }));
-            const text = utils_1.render(this.templates.schema, {
-                importList: this._prepareImportList(),
-                data: utils_1.objectToTemplateValue(this.formattedSchema),
-                hasOneOf: oneOfs.length > 0,
-                oneOfs,
-                useTypeScript: this.useTypeScript,
-            }, {
-                head: this.templates.head,
-                oneOf: this.templates.oneOf,
-            });
-            return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
-        }
-        _prepareImportList() {
-            const relative = path_1.default.relative(this.outputDir, this.modelsDir);
-            return this.importModels.map(({ modelName }) => {
-                return {
-                    name: utils_1.schemaName(modelName),
-                    path: path_1.default.join(relative, lodash_1.default.snakeCase(modelName)),
-                };
-            });
-        }
-        get importModels() {
-            return lodash_1.default.uniqBy(this._importModels, 'modelName');
-        }
-        get formattedSchema() {
-            return lodash_1.default.reduce(this.parsedObjects, (acc, schema, key) => {
-                acc[key] = utils_1.changeFormat(schema, this.attributeConverter);
-                return acc;
-            }, {});
-        }
-        static getJsonContents(response) {
-            return response.content && response.content['application/json'];
-        }
+        });
     }
-    exports.default = SchemaGenerator;
-});
+    /**
+     * パース情報とテンプレートからschema.jsとmodels/index.js書き出し
+     */
+    write() {
+        return Promise.all([
+            this._writeSchemaFile(),
+            this.importModels.map(({ modelName, model }) => this.modelGenerator.writeModel(model, modelName)),
+        ]).then(() => {
+            this.modelGenerator.writeIndex();
+        });
+    }
+    _writeSchemaFile() {
+        const oneOfs = this.oneOfs.map((obj) => Object.assign(obj, {
+            mapping: utils_1.objectToTemplateValue(obj.mapping),
+            propertyName: `'${this.attributeConverter(obj.propertyName)}'`,
+        }));
+        const text = utils_1.render(this.templates.schema, {
+            importList: this._prepareImportList(),
+            data: utils_1.objectToTemplateValue(this.formattedSchema),
+            hasOneOf: oneOfs.length > 0,
+            oneOfs,
+            useTypeScript: this.useTypeScript,
+        }, {
+            head: this.templates.head,
+            oneOf: this.templates.oneOf,
+        });
+        return utils_1.writeFilePromise(path_1.default.join(this.outputDir, this.outputFileName), text);
+    }
+    _prepareImportList() {
+        const relative = path_1.default.relative(this.outputDir, this.modelsDir);
+        return this.importModels.map(({ modelName }) => {
+            return {
+                name: utils_1.schemaName(modelName),
+                path: path_1.default.join(relative, lodash_1.default.snakeCase(modelName)),
+            };
+        });
+    }
+    get importModels() {
+        return lodash_1.default.uniqBy(this._importModels, 'modelName');
+    }
+    get formattedSchema() {
+        return lodash_1.default.reduce(this.parsedObjects, (acc, schema, key) => {
+            acc[key] = utils_1.changeFormat(schema, this.attributeConverter);
+            return acc;
+        }, {});
+    }
+    static getJsonContents(response) {
+        return response.content && response.content['application/json'];
+    }
+}
+exports.default = SchemaGenerator;

--- a/dist/compiled/schema_generator.js
+++ b/dist/compiled/schema_generator.js
@@ -124,5 +124,5 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             return response.content && response.content['application/json'];
         }
     }
-    module.exports = SchemaGenerator;
+    exports.default = SchemaGenerator;
 });

--- a/dist/compiled/spec_file_utils.js
+++ b/dist/compiled/spec_file_utils.js
@@ -1,149 +1,139 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = __importDefault(require("fs"));
+const os_1 = __importDefault(require("os"));
+const path_1 = __importDefault(require("path"));
+const mkdirp_1 = __importDefault(require("mkdirp"));
+const merge_1 = __importDefault(require("lodash/merge"));
+const noop_1 = __importDefault(require("lodash/noop"));
+const isArray_1 = __importDefault(require("lodash/isArray"));
+const isObject_1 = __importDefault(require("lodash/isObject"));
+const each_1 = __importDefault(require("lodash/each"));
+const uniq_1 = __importDefault(require("lodash/uniq"));
+const flatten_1 = __importDefault(require("lodash/flatten"));
+const js_yaml_1 = __importDefault(require("js-yaml"));
+const json_schema_ref_parser_1 = __importDefault(require("json-schema-ref-parser"));
+exports.ALTERNATIVE_REF_KEY = '__$ref__';
+exports.MODEL_DEF_KEY = 'x-model-name';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isOperation = (obj) => 'tags' in obj;
+const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+const isMethodName = (str) => methodNames.includes(str);
+function readSpecFilePromise(path, options = {}) {
+    const data = fs_1.default.readFileSync(path, 'utf8');
+    const original = js_yaml_1.default.safeLoad(data);
+    if (!options.dereference)
+        return Promise.resolve(original);
+    return new Promise((resolve, reject) => {
+        json_schema_ref_parser_1.default.dereference(path, (err, schema) => {
+            schema = merge_1.default(original, schema);
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(schema);
+        });
+    });
+}
+exports.readSpecFilePromise = readSpecFilePromise;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function walkSchema(spec, callback = noop_1.default) {
+    if (isArray_1.default(spec)) {
+        return spec.forEach((item) => walkSchema(item, callback));
     }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "fs", "os", "path", "mkdirp", "lodash/merge", "lodash/noop", "lodash/isArray", "lodash/isObject", "lodash/each", "lodash/uniq", "lodash/flatten", "js-yaml", "json-schema-ref-parser"], factory);
+    else if (isObject_1.default(spec)) {
+        callback(spec);
+        return each_1.default(spec, (value) => walkSchema(value, callback));
     }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    const fs_1 = __importDefault(require("fs"));
-    const os_1 = __importDefault(require("os"));
-    const path_1 = __importDefault(require("path"));
-    const mkdirp_1 = __importDefault(require("mkdirp"));
-    const merge_1 = __importDefault(require("lodash/merge"));
-    const noop_1 = __importDefault(require("lodash/noop"));
-    const isArray_1 = __importDefault(require("lodash/isArray"));
-    const isObject_1 = __importDefault(require("lodash/isObject"));
-    const each_1 = __importDefault(require("lodash/each"));
-    const uniq_1 = __importDefault(require("lodash/uniq"));
-    const flatten_1 = __importDefault(require("lodash/flatten"));
-    const js_yaml_1 = __importDefault(require("js-yaml"));
-    const json_schema_ref_parser_1 = __importDefault(require("json-schema-ref-parser"));
-    exports.ALTERNATIVE_REF_KEY = '__$ref__';
-    exports.MODEL_DEF_KEY = 'x-model-name';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const isOperation = (obj) => 'tags' in obj;
-    const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
-    const isMethodName = (str) => methodNames.includes(str);
-    function readSpecFilePromise(path, options = {}) {
-        const data = fs_1.default.readFileSync(path, 'utf8');
-        const original = js_yaml_1.default.safeLoad(data);
-        if (!options.dereference)
-            return Promise.resolve(original);
-        return new Promise((resolve, reject) => {
-            json_schema_ref_parser_1.default.dereference(path, (err, schema) => {
-                schema = merge_1.default(original, schema);
-                if (err) {
-                    reject(err);
-                    return;
+}
+exports.walkSchema = walkSchema;
+function getRefFilesPath(spec) {
+    const paths = [];
+    walkSchema(spec, (obj) => {
+        if (obj.$ref) {
+            const matches = obj.$ref.match(/^([^#].*)#/);
+            if (matches)
+                paths.push(matches[1]);
+        }
+    });
+    return paths;
+}
+function applyAlternativeRef(spec) {
+    walkSchema(spec, (obj) => {
+        if (obj.$ref) {
+            obj[exports.ALTERNATIVE_REF_KEY] = obj.$ref;
+        }
+    });
+    return spec;
+}
+function convertToLocalDefinition(spec) {
+    walkSchema(spec, (obj) => {
+        if (obj.$ref) {
+            const index = obj.$ref.indexOf('#');
+            obj.$ref = obj.$ref.slice(index);
+        }
+    });
+    return spec;
+}
+exports.convertToLocalDefinition = convertToLocalDefinition;
+function getPreparedSpecFilePaths(specFiles, tags = []) {
+    const readFiles = {};
+    const tmpDir = fs_1.default.mkdtempSync(path_1.default.join(fs_1.default.realpathSync(os_1.default.tmpdir()), '__openapi_to_normalizr__'));
+    const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
+    return specFiles.concat(allFiles).map((p) => {
+        const target = path_1.default.join(tmpDir, p);
+        mkdirp_1.default.sync(path_1.default.dirname(target));
+        const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(p).toString());
+        if (specFiles.includes(p)) {
+            removeUnusableOperation(spec);
+        }
+        else {
+            delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
+        }
+        applyAlternativeRef(spec);
+        const schemas = spec.components && spec.components.schemas;
+        if (schemas) {
+            each_1.default(schemas, (model, name) => {
+                model[exports.MODEL_DEF_KEY] = name;
+            });
+        }
+        fs_1.default.writeFileSync(target, js_yaml_1.default.safeDump(spec));
+        return target;
+    });
+    function isUsableOperation(operationTags) {
+        if (tags.length === 0)
+            return true;
+        return operationTags && tags.some((t) => operationTags.includes(t));
+    }
+    function removeUnusableOperation(spec) {
+        each_1.default(spec.paths, (operations) => {
+            each_1.default(operations, (operation, method) => {
+                if (isOperation(operation) && isMethodName(method) && !isUsableOperation(operation.tags)) {
+                    delete operations[method];
                 }
-                resolve(schema);
             });
         });
     }
-    exports.readSpecFilePromise = readSpecFilePromise;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function walkSchema(spec, callback = noop_1.default) {
-        if (isArray_1.default(spec)) {
-            return spec.forEach((item) => walkSchema(item, callback));
-        }
-        else if (isObject_1.default(spec)) {
-            callback(spec);
-            return each_1.default(spec, (value) => walkSchema(value, callback));
-        }
+    function getAllRelatedFiles(files) {
+        return files.reduce((acc, filePath) => {
+            const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(filePath).toString());
+            const refFilesPaths = uniq_1.default(getRefFilesPath(spec));
+            const relatedFilesPaths = flatten_1.default(refFilesPaths.map((p) => {
+                const refSpecPath = path_1.default.join(path_1.default.dirname(filePath), p);
+                if (readFiles[refSpecPath]) {
+                    return refSpecPath;
+                }
+                else {
+                    readFiles[refSpecPath] = true;
+                    const relatedFiles = getAllRelatedFiles([refSpecPath]);
+                    return [refSpecPath].concat(relatedFiles);
+                }
+            }));
+            return acc.concat(relatedFilesPaths);
+        }, []);
     }
-    exports.walkSchema = walkSchema;
-    function getRefFilesPath(spec) {
-        const paths = [];
-        walkSchema(spec, (obj) => {
-            if (obj.$ref) {
-                const matches = obj.$ref.match(/^([^#].*)#/);
-                if (matches)
-                    paths.push(matches[1]);
-            }
-        });
-        return paths;
-    }
-    function applyAlternativeRef(spec) {
-        walkSchema(spec, (obj) => {
-            if (obj.$ref) {
-                obj[exports.ALTERNATIVE_REF_KEY] = obj.$ref;
-            }
-        });
-        return spec;
-    }
-    function convertToLocalDefinition(spec) {
-        walkSchema(spec, (obj) => {
-            if (obj.$ref) {
-                const index = obj.$ref.indexOf('#');
-                obj.$ref = obj.$ref.slice(index);
-            }
-        });
-        return spec;
-    }
-    exports.convertToLocalDefinition = convertToLocalDefinition;
-    function getPreparedSpecFilePaths(specFiles, tags = []) {
-        const readFiles = {};
-        const tmpDir = fs_1.default.mkdtempSync(path_1.default.join(fs_1.default.realpathSync(os_1.default.tmpdir()), '__openapi_to_normalizr__'));
-        const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
-        return specFiles.concat(allFiles).map((p) => {
-            const target = path_1.default.join(tmpDir, p);
-            mkdirp_1.default.sync(path_1.default.dirname(target));
-            const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(p).toString());
-            if (specFiles.includes(p)) {
-                removeUnusableOperation(spec);
-            }
-            else {
-                delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
-            }
-            applyAlternativeRef(spec);
-            const schemas = spec.components && spec.components.schemas;
-            if (schemas) {
-                each_1.default(schemas, (model, name) => {
-                    model[exports.MODEL_DEF_KEY] = name;
-                });
-            }
-            fs_1.default.writeFileSync(target, js_yaml_1.default.safeDump(spec));
-            return target;
-        });
-        function isUsableOperation(operationTags) {
-            if (tags.length === 0)
-                return true;
-            return operationTags && tags.some((t) => operationTags.includes(t));
-        }
-        function removeUnusableOperation(spec) {
-            each_1.default(spec.paths, (operations) => {
-                each_1.default(operations, (operation, method) => {
-                    if (isOperation(operation) && isMethodName(method) && !isUsableOperation(operation.tags)) {
-                        delete operations[method];
-                    }
-                });
-            });
-        }
-        function getAllRelatedFiles(files) {
-            return files.reduce((acc, filePath) => {
-                const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(filePath).toString());
-                const refFilesPaths = uniq_1.default(getRefFilesPath(spec));
-                const relatedFilesPaths = flatten_1.default(refFilesPaths.map((p) => {
-                    const refSpecPath = path_1.default.join(path_1.default.dirname(filePath), p);
-                    if (readFiles[refSpecPath]) {
-                        return refSpecPath;
-                    }
-                    else {
-                        readFiles[refSpecPath] = true;
-                        const relatedFiles = getAllRelatedFiles([refSpecPath]);
-                        return [refSpecPath].concat(relatedFiles);
-                    }
-                }));
-                return acc.concat(relatedFilesPaths);
-            }, []);
-        }
-    }
-    exports.getPreparedSpecFilePaths = getPreparedSpecFilePaths;
-});
+}
+exports.getPreparedSpecFilePaths = getPreparedSpecFilePaths;

--- a/dist/compiled/spec_file_utils.js
+++ b/dist/compiled/spec_file_utils.js
@@ -1,142 +1,149 @@
-"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-const fs_1 = __importDefault(require("fs"));
-const os_1 = __importDefault(require("os"));
-const path_1 = __importDefault(require("path"));
-const mkdirp_1 = __importDefault(require("mkdirp"));
-const merge_1 = __importDefault(require("lodash/merge"));
-const noop_1 = __importDefault(require("lodash/noop"));
-const isArray_1 = __importDefault(require("lodash/isArray"));
-const isObject_1 = __importDefault(require("lodash/isObject"));
-const each_1 = __importDefault(require("lodash/each"));
-const uniq_1 = __importDefault(require("lodash/uniq"));
-const flatten_1 = __importDefault(require("lodash/flatten"));
-const js_yaml_1 = __importDefault(require("js-yaml"));
-const json_schema_ref_parser_1 = __importDefault(require("json-schema-ref-parser"));
-const ALTERNATIVE_REF_KEY = '__$ref__';
-const MODEL_DEF_KEY = 'x-model-name';
-const isOperation = (obj) => 'tags' in obj;
-const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
-const isMethodName = (str) => methodNames.includes(str);
-function readSpecFilePromise(path, options = {}) {
-    const data = fs_1.default.readFileSync(path, 'utf8');
-    const original = js_yaml_1.default.safeLoad(data);
-    if (!options.dereference)
-        return Promise.resolve(original);
-    return new Promise((resolve, reject) => {
-        json_schema_ref_parser_1.default.dereference(path, (err, schema) => {
-            schema = merge_1.default(original, schema);
-            if (err) {
-                reject(err);
-                return;
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "fs", "os", "path", "mkdirp", "lodash/merge", "lodash/noop", "lodash/isArray", "lodash/isObject", "lodash/each", "lodash/uniq", "lodash/flatten", "js-yaml", "json-schema-ref-parser"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const fs_1 = __importDefault(require("fs"));
+    const os_1 = __importDefault(require("os"));
+    const path_1 = __importDefault(require("path"));
+    const mkdirp_1 = __importDefault(require("mkdirp"));
+    const merge_1 = __importDefault(require("lodash/merge"));
+    const noop_1 = __importDefault(require("lodash/noop"));
+    const isArray_1 = __importDefault(require("lodash/isArray"));
+    const isObject_1 = __importDefault(require("lodash/isObject"));
+    const each_1 = __importDefault(require("lodash/each"));
+    const uniq_1 = __importDefault(require("lodash/uniq"));
+    const flatten_1 = __importDefault(require("lodash/flatten"));
+    const js_yaml_1 = __importDefault(require("js-yaml"));
+    const json_schema_ref_parser_1 = __importDefault(require("json-schema-ref-parser"));
+    exports.ALTERNATIVE_REF_KEY = '__$ref__';
+    exports.MODEL_DEF_KEY = 'x-model-name';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const isOperation = (obj) => 'tags' in obj;
+    const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+    const isMethodName = (str) => methodNames.includes(str);
+    function readSpecFilePromise(path, options = {}) {
+        const data = fs_1.default.readFileSync(path, 'utf8');
+        const original = js_yaml_1.default.safeLoad(data);
+        if (!options.dereference)
+            return Promise.resolve(original);
+        return new Promise((resolve, reject) => {
+            json_schema_ref_parser_1.default.dereference(path, (err, schema) => {
+                schema = merge_1.default(original, schema);
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve(schema);
+            });
+        });
+    }
+    exports.readSpecFilePromise = readSpecFilePromise;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function walkSchema(spec, callback = noop_1.default) {
+        if (isArray_1.default(spec)) {
+            return spec.forEach((item) => walkSchema(item, callback));
+        }
+        else if (isObject_1.default(spec)) {
+            callback(spec);
+            return each_1.default(spec, (value) => walkSchema(value, callback));
+        }
+    }
+    exports.walkSchema = walkSchema;
+    function getRefFilesPath(spec) {
+        const paths = [];
+        walkSchema(spec, (obj) => {
+            if (obj.$ref) {
+                const matches = obj.$ref.match(/^([^#].*)#/);
+                if (matches)
+                    paths.push(matches[1]);
             }
-            resolve(schema);
         });
-    });
-}
-function walkSchema(spec, callback = noop_1.default) {
-    if (isArray_1.default(spec)) {
-        return spec.forEach((item) => walkSchema(item, callback));
+        return paths;
     }
-    else if (isObject_1.default(spec)) {
-        callback(spec);
-        return each_1.default(spec, (value) => walkSchema(value, callback));
+    function applyAlternativeRef(spec) {
+        walkSchema(spec, (obj) => {
+            if (obj.$ref) {
+                obj[exports.ALTERNATIVE_REF_KEY] = obj.$ref;
+            }
+        });
+        return spec;
     }
-}
-function getRefFilesPath(spec) {
-    const paths = [];
-    walkSchema(spec, (obj) => {
-        if (obj.$ref) {
-            const matches = obj.$ref.match(/^([^#].*)#/);
-            if (matches)
-                paths.push(matches[1]);
+    function convertToLocalDefinition(spec) {
+        walkSchema(spec, (obj) => {
+            if (obj.$ref) {
+                const index = obj.$ref.indexOf('#');
+                obj.$ref = obj.$ref.slice(index);
+            }
+        });
+        return spec;
+    }
+    exports.convertToLocalDefinition = convertToLocalDefinition;
+    function getPreparedSpecFilePaths(specFiles, tags = []) {
+        const readFiles = {};
+        const tmpDir = fs_1.default.mkdtempSync(path_1.default.join(fs_1.default.realpathSync(os_1.default.tmpdir()), '__openapi_to_normalizr__'));
+        const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
+        return specFiles.concat(allFiles).map((p) => {
+            const target = path_1.default.join(tmpDir, p);
+            mkdirp_1.default.sync(path_1.default.dirname(target));
+            const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(p).toString());
+            if (specFiles.includes(p)) {
+                removeUnusableOperation(spec);
+            }
+            else {
+                delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
+            }
+            applyAlternativeRef(spec);
+            const schemas = spec.components && spec.components.schemas;
+            if (schemas) {
+                each_1.default(schemas, (model, name) => {
+                    model[exports.MODEL_DEF_KEY] = name;
+                });
+            }
+            fs_1.default.writeFileSync(target, js_yaml_1.default.safeDump(spec));
+            return target;
+        });
+        function isUsableOperation(operationTags) {
+            if (tags.length === 0)
+                return true;
+            return operationTags && tags.some((t) => operationTags.includes(t));
         }
-    });
-    return paths;
-}
-function applyAlternativeRef(spec) {
-    walkSchema(spec, (obj) => {
-        if (obj.$ref) {
-            obj[ALTERNATIVE_REF_KEY] = obj.$ref;
-        }
-    });
-    return spec;
-}
-function convertToLocalDefinition(spec) {
-    walkSchema(spec, (obj) => {
-        if (obj.$ref) {
-            const index = obj.$ref.indexOf('#');
-            obj.$ref = obj.$ref.slice(index);
-        }
-    });
-    return spec;
-}
-function getPreparedSpecFilePaths(specFiles, tags = []) {
-    const readFiles = {};
-    const tmpDir = fs_1.default.mkdtempSync(path_1.default.join(fs_1.default.realpathSync(os_1.default.tmpdir()), '__openapi_to_normalizr__'));
-    const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
-    return specFiles.concat(allFiles).map((p) => {
-        const target = path_1.default.join(tmpDir, p);
-        mkdirp_1.default.sync(path_1.default.dirname(target));
-        const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(p).toString());
-        if (specFiles.includes(p)) {
-            removeUnusableOperation(spec);
-        }
-        else {
-            delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
-        }
-        applyAlternativeRef(spec);
-        const schemas = spec.components && spec.components.schemas;
-        if (schemas) {
-            each_1.default(schemas, (model, name) => {
-                model[MODEL_DEF_KEY] = name;
+        function removeUnusableOperation(spec) {
+            each_1.default(spec.paths, (operations) => {
+                each_1.default(operations, (operation, method) => {
+                    if (isOperation(operation) && isMethodName(method) && !isUsableOperation(operation.tags)) {
+                        delete operations[method];
+                    }
+                });
             });
         }
-        fs_1.default.writeFileSync(target, js_yaml_1.default.safeDump(spec));
-        return target;
-    });
-    function isUsableOperation(operationTags) {
-        if (tags.length === 0)
-            return true;
-        return operationTags && tags.some((t) => operationTags.includes(t));
+        function getAllRelatedFiles(files) {
+            return files.reduce((acc, filePath) => {
+                const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(filePath).toString());
+                const refFilesPaths = uniq_1.default(getRefFilesPath(spec));
+                const relatedFilesPaths = flatten_1.default(refFilesPaths.map((p) => {
+                    const refSpecPath = path_1.default.join(path_1.default.dirname(filePath), p);
+                    if (readFiles[refSpecPath]) {
+                        return refSpecPath;
+                    }
+                    else {
+                        readFiles[refSpecPath] = true;
+                        const relatedFiles = getAllRelatedFiles([refSpecPath]);
+                        return [refSpecPath].concat(relatedFiles);
+                    }
+                }));
+                return acc.concat(relatedFilesPaths);
+            }, []);
+        }
     }
-    function removeUnusableOperation(spec) {
-        each_1.default(spec.paths, (operations) => {
-            each_1.default(operations, (operation, method) => {
-                if (isOperation(operation) && isMethodName(method) && !isUsableOperation(operation.tags)) {
-                    delete operations[method];
-                }
-            });
-        });
-    }
-    function getAllRelatedFiles(files) {
-        console.log('hell');
-        return files.reduce((acc, filePath) => {
-            const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(filePath).toString());
-            const refFilesPaths = uniq_1.default(getRefFilesPath(spec));
-            const relatedFilesPaths = flatten_1.default(refFilesPaths.map((p) => {
-                const refSpecPath = path_1.default.join(path_1.default.dirname(filePath), p);
-                if (readFiles[refSpecPath]) {
-                    return refSpecPath;
-                }
-                else {
-                    readFiles[refSpecPath] = true;
-                    const relatedFiles = getAllRelatedFiles([refSpecPath]);
-                    return [refSpecPath].concat(relatedFiles);
-                }
-            }));
-            return acc.concat(relatedFilesPaths);
-        }, []);
-    }
-}
-module.exports = {
-    readSpecFilePromise,
-    getPreparedSpecFilePaths,
-    convertToLocalDefinition,
-    walkSchema,
-    ALTERNATIVE_REF_KEY,
-    MODEL_DEF_KEY,
-};
+    exports.getPreparedSpecFilePaths = getPreparedSpecFilePaths;
+});

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -1,222 +1,212 @@
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-(function (factory) {
-    if (typeof module === "object" && typeof module.exports === "object") {
-        var v = factory(require, exports);
-        if (v !== undefined) module.exports = v;
-    }
-    else if (typeof define === "function" && define.amd) {
-        define(["require", "exports", "fs", "path", "mkdirp", "lodash", "mustache", "./spec_file_utils"], factory);
-    }
-})(function (require, exports) {
-    "use strict";
-    Object.defineProperty(exports, "__esModule", { value: true });
-    // @ts-nocheck
-    const fs_1 = __importDefault(require("fs"));
-    const path_1 = __importDefault(require("path"));
-    const mkdirp_1 = __importDefault(require("mkdirp"));
-    const lodash_1 = __importDefault(require("lodash"));
-    const mustache_1 = __importDefault(require("mustache"));
-    const spec_file_utils_1 = require("./spec_file_utils");
-    const cwd = process.cwd();
-    const now = new Date();
-    function schemaName(modelName) {
-        return `${modelName}Schema`;
-    }
-    exports.schemaName = schemaName;
-    function getModelName(schema) {
-        return schema && schema[spec_file_utils_1.MODEL_DEF_KEY];
-    }
-    exports.getModelName = getModelName;
-    function applyIf(data, applyFn = (val) => val) {
-        return data && applyFn(data);
-    }
-    exports.applyIf = applyIf;
-    function getRef(schema) {
-        return schema.$ref || schema.$$ref || schema[spec_file_utils_1.ALTERNATIVE_REF_KEY]; // $$ref by swagger-client
-    }
-    function parseOneOf(schema, onSchema) {
-        const { propertyName, mapping } = schema.discriminator;
-        const ret = {
-            propertyName,
+Object.defineProperty(exports, "__esModule", { value: true });
+// @ts-nocheck
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const mkdirp_1 = __importDefault(require("mkdirp"));
+const lodash_1 = __importDefault(require("lodash"));
+const mustache_1 = __importDefault(require("mustache"));
+const spec_file_utils_1 = require("./spec_file_utils");
+const cwd = process.cwd();
+const now = new Date();
+function schemaName(modelName) {
+    return `${modelName}Schema`;
+}
+exports.schemaName = schemaName;
+function getModelName(schema) {
+    return schema && schema[spec_file_utils_1.MODEL_DEF_KEY];
+}
+exports.getModelName = getModelName;
+function applyIf(data, applyFn = (val) => val) {
+    return data && applyFn(data);
+}
+exports.applyIf = applyIf;
+function getRef(schema) {
+    return schema.$ref || schema.$$ref || schema[spec_file_utils_1.ALTERNATIVE_REF_KEY]; // $$ref by swagger-client
+}
+function parseOneOf(schema, onSchema) {
+    const { propertyName, mapping } = schema.discriminator;
+    const ret = {
+        propertyName,
+    };
+    const components = schema.oneOf.map((model) => {
+        const modelName = getModelName(model);
+        onSchema({
+            type: 'model',
+            value: model,
+        });
+        return {
+            name: modelName,
+            schemaName: schemaName(modelName),
+            value: model,
         };
-        const components = schema.oneOf.map((model) => {
-            const modelName = getModelName(model);
-            onSchema({
-                type: 'model',
-                value: model,
-            });
-            return {
-                name: modelName,
-                schemaName: schemaName(modelName),
-                value: model,
-            };
-        });
-        if (mapping) {
-            ret.mapping = lodash_1.default.reduce(mapping, (acc, model, key) => {
-                const { schemaName } = lodash_1.default.find(components, ({ value }) => getRef(value) === model);
-                acc[key] = schemaName;
-                return acc;
-            }, {});
-        }
-        else {
-            ret.mapping = lodash_1.default.reduce(components, (acc, { name, schemaName }) => {
-                acc[name] = schemaName;
-                return acc;
-            }, {});
-        }
-        return ret;
-    }
-    function parseSchema(schema, onSchema) {
-        if (!lodash_1.default.isObject(schema))
-            return;
-        const modelName = getModelName(schema);
-        if (modelName && getIdAttribute(schema)) {
-            return onSchema({
-                type: 'model',
-                value: schema,
-            });
-        }
-        else if (schema.oneOf && schema.discriminator) {
-            return onSchema({
-                type: 'oneOf',
-                value: parseOneOf(schema, onSchema),
-            });
-        }
-        else if (schema.type === 'object') {
-            return applyIf(parseSchema(schema.properties, onSchema));
-        }
-        else if (schema.type === 'array') {
-            return applyIf(parseSchema(schema.items, onSchema), (val) => [val]);
-        }
-        else {
-            const reduced = lodash_1.default.reduce(schema, (ret, val, key) => {
-                const tmp = parseSchema(val, onSchema);
-                if (tmp) {
-                    ret[key] = tmp;
-                }
-                return ret;
-            }, {});
-            if (Object.keys(reduced).length > 0) {
-                return reduced;
-            }
-        }
-    }
-    exports.parseSchema = parseSchema;
-    function isFileExistPromise(path) {
-        return new Promise((resolve, reject) => {
-            fs_1.default.access(path, (err) => {
-                if (!err) {
-                    resolve(true); // file is exist.
-                    return;
-                }
-                if (err.code === 'ENOENT') {
-                    // file is not exist.
-                    resolve(false);
-                }
-                else {
-                    reject(err);
-                }
-            });
-        });
-    }
-    exports.isFileExistPromise = isFileExistPromise;
-    function applyRequired(props, requiredList) {
-        if (!lodash_1.default.isArray(requiredList)) {
-            return props;
-        }
-        return lodash_1.default.reduce(props, (ret, prop, key) => {
-            ret[key] = prop;
-            if (requiredList.includes(key)) {
-                prop.required = true;
-            }
-            return ret;
-        }, {});
-    }
-    exports.applyRequired = applyRequired;
-    function resolvePath(str) {
-        return path_1.default.isAbsolute(str) ? str : path_1.default.join(cwd, str);
-    }
-    exports.resolvePath = resolvePath;
-    function mkdirpPromise(dir) {
-        return mkdirp_1.default(dir);
-    }
-    exports.mkdirpPromise = mkdirpPromise;
-    function writeFilePromise(path, data) {
-        return new Promise((resolve, reject) => fs_1.default.writeFile(path, data, (err) => (err ? reject(err) : resolve())));
-    }
-    exports.writeFilePromise = writeFilePromise;
-    function writeFile(path, data) {
-        return fs_1.default.writeFileSync(path, data);
-    }
-    exports.writeFile = writeFile;
-    function readTemplates(keys = [], templatePath) {
-        return keys.reduce((ret, key) => {
-            ret[key] = fs_1.default.readFileSync(templatePath[key], 'utf8');
-            return ret;
-        }, {});
-    }
-    exports.readTemplates = readTemplates;
-    function render(template, data = {}, option = {}) {
-        if (option.withDate) {
-            data.date = now;
-            delete option.withDate;
-        }
-        return mustache_1.default.render(template, data, option);
-    }
-    exports.render = render;
-    function objectToTemplateValue(object) {
-        if (!lodash_1.default.isObject(object)) {
-            return;
-        }
-        return JSON.stringify(object, null, 2).replace(/"/g, '');
-    }
-    exports.objectToTemplateValue = objectToTemplateValue;
-    function changeFormat(obj, transformer) {
-        if (typeof obj === 'object') {
-            if (obj === null) {
-                return obj;
-            }
-            const formattedObj = Array.isArray(obj) ? [] : {};
-            const keys = Object.keys(obj);
-            keys.forEach((key) => {
-                const value = obj[key];
-                formattedObj[transformer(key)] = changeFormat(value, transformer);
-            });
-            return formattedObj;
-        }
-        else {
-            return obj;
-        }
-    }
-    exports.changeFormat = changeFormat;
-    function getIdAttribute(model, name) {
-        const { properties } = model;
-        if (!properties) {
-            if (name) {
-                console.warn(`${name} is not model definition.`); // eslint-disable-line no-console
-            }
-            return false;
-        }
-        const idAttribute = model['x-id-attribute'] ? model['x-id-attribute'] : 'id';
-        if (!idAttribute.includes('.') && !properties[idAttribute]) {
-            if (name) {
-                console.warn(`${name} is not generated without id attribute.`); // eslint-disable-line no-console
-            }
-            return false;
-        }
-        return idAttribute;
-    }
-    exports.getIdAttribute = getIdAttribute;
-    function getModelDefinitions(spec) {
-        return lodash_1.default.reduce(spec.components.schemas, (acc, model) => {
-            const modelName = getModelName(model);
-            if (modelName) {
-                acc[modelName] = model;
-            }
+    });
+    if (mapping) {
+        ret.mapping = lodash_1.default.reduce(mapping, (acc, model, key) => {
+            const { schemaName } = lodash_1.default.find(components, ({ value }) => getRef(value) === model);
+            acc[key] = schemaName;
             return acc;
         }, {});
     }
-    exports.getModelDefinitions = getModelDefinitions;
-});
+    else {
+        ret.mapping = lodash_1.default.reduce(components, (acc, { name, schemaName }) => {
+            acc[name] = schemaName;
+            return acc;
+        }, {});
+    }
+    return ret;
+}
+function parseSchema(schema, onSchema) {
+    if (!lodash_1.default.isObject(schema))
+        return;
+    const modelName = getModelName(schema);
+    if (modelName && getIdAttribute(schema)) {
+        return onSchema({
+            type: 'model',
+            value: schema,
+        });
+    }
+    else if (schema.oneOf && schema.discriminator) {
+        return onSchema({
+            type: 'oneOf',
+            value: parseOneOf(schema, onSchema),
+        });
+    }
+    else if (schema.type === 'object') {
+        return applyIf(parseSchema(schema.properties, onSchema));
+    }
+    else if (schema.type === 'array') {
+        return applyIf(parseSchema(schema.items, onSchema), (val) => [val]);
+    }
+    else {
+        const reduced = lodash_1.default.reduce(schema, (ret, val, key) => {
+            const tmp = parseSchema(val, onSchema);
+            if (tmp) {
+                ret[key] = tmp;
+            }
+            return ret;
+        }, {});
+        if (Object.keys(reduced).length > 0) {
+            return reduced;
+        }
+    }
+}
+exports.parseSchema = parseSchema;
+function isFileExistPromise(path) {
+    return new Promise((resolve, reject) => {
+        fs_1.default.access(path, (err) => {
+            if (!err) {
+                resolve(true); // file is exist.
+                return;
+            }
+            if (err.code === 'ENOENT') {
+                // file is not exist.
+                resolve(false);
+            }
+            else {
+                reject(err);
+            }
+        });
+    });
+}
+exports.isFileExistPromise = isFileExistPromise;
+function applyRequired(props, requiredList) {
+    if (!lodash_1.default.isArray(requiredList)) {
+        return props;
+    }
+    return lodash_1.default.reduce(props, (ret, prop, key) => {
+        ret[key] = prop;
+        if (requiredList.includes(key)) {
+            prop.required = true;
+        }
+        return ret;
+    }, {});
+}
+exports.applyRequired = applyRequired;
+function resolvePath(str) {
+    return path_1.default.isAbsolute(str) ? str : path_1.default.join(cwd, str);
+}
+exports.resolvePath = resolvePath;
+function mkdirpPromise(dir) {
+    return mkdirp_1.default(dir);
+}
+exports.mkdirpPromise = mkdirpPromise;
+function writeFilePromise(path, data) {
+    return new Promise((resolve, reject) => fs_1.default.writeFile(path, data, (err) => (err ? reject(err) : resolve())));
+}
+exports.writeFilePromise = writeFilePromise;
+function writeFile(path, data) {
+    return fs_1.default.writeFileSync(path, data);
+}
+exports.writeFile = writeFile;
+function readTemplates(keys = [], templatePath) {
+    return keys.reduce((ret, key) => {
+        ret[key] = fs_1.default.readFileSync(templatePath[key], 'utf8');
+        return ret;
+    }, {});
+}
+exports.readTemplates = readTemplates;
+function render(template, data = {}, option = {}) {
+    if (option.withDate) {
+        data.date = now;
+        delete option.withDate;
+    }
+    return mustache_1.default.render(template, data, option);
+}
+exports.render = render;
+function objectToTemplateValue(object) {
+    if (!lodash_1.default.isObject(object)) {
+        return;
+    }
+    return JSON.stringify(object, null, 2).replace(/"/g, '');
+}
+exports.objectToTemplateValue = objectToTemplateValue;
+function changeFormat(obj, transformer) {
+    if (typeof obj === 'object') {
+        if (obj === null) {
+            return obj;
+        }
+        const formattedObj = Array.isArray(obj) ? [] : {};
+        const keys = Object.keys(obj);
+        keys.forEach((key) => {
+            const value = obj[key];
+            formattedObj[transformer(key)] = changeFormat(value, transformer);
+        });
+        return formattedObj;
+    }
+    else {
+        return obj;
+    }
+}
+exports.changeFormat = changeFormat;
+function getIdAttribute(model, name) {
+    const { properties } = model;
+    if (!properties) {
+        if (name) {
+            console.warn(`${name} is not model definition.`); // eslint-disable-line no-console
+        }
+        return false;
+    }
+    const idAttribute = model['x-id-attribute'] ? model['x-id-attribute'] : 'id';
+    if (!idAttribute.includes('.') && !properties[idAttribute]) {
+        if (name) {
+            console.warn(`${name} is not generated without id attribute.`); // eslint-disable-line no-console
+        }
+        return false;
+    }
+    return idAttribute;
+}
+exports.getIdAttribute = getIdAttribute;
+function getModelDefinitions(spec) {
+    return lodash_1.default.reduce(spec.components.schemas, (acc, model) => {
+        const modelName = getModelName(model);
+        if (modelName) {
+            acc[modelName] = model;
+        }
+        return acc;
+    }, {});
+}
+exports.getModelDefinitions = getModelDefinitions;

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -24,12 +24,15 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     function schemaName(modelName) {
         return `${modelName}Schema`;
     }
+    exports.schemaName = schemaName;
     function getModelName(schema) {
         return schema && schema[spec_file_utils_1.MODEL_DEF_KEY];
     }
+    exports.getModelName = getModelName;
     function applyIf(data, applyFn = (val) => val) {
         return data && applyFn(data);
     }
+    exports.applyIf = applyIf;
     function getRef(schema) {
         return schema.$ref || schema.$$ref || schema[spec_file_utils_1.ALTERNATIVE_REF_KEY]; // $$ref by swagger-client
     }
@@ -100,6 +103,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             }
         }
     }
+    exports.parseSchema = parseSchema;
     function isFileExistPromise(path) {
         return new Promise((resolve, reject) => {
             fs_1.default.access(path, (err) => {
@@ -117,6 +121,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             });
         });
     }
+    exports.isFileExistPromise = isFileExistPromise;
     function applyRequired(props, requiredList) {
         if (!lodash_1.default.isArray(requiredList)) {
             return props;
@@ -129,24 +134,30 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             return ret;
         }, {});
     }
+    exports.applyRequired = applyRequired;
     function resolvePath(str) {
         return path_1.default.isAbsolute(str) ? str : path_1.default.join(cwd, str);
     }
+    exports.resolvePath = resolvePath;
     function mkdirpPromise(dir) {
         return mkdirp_1.default(dir);
     }
+    exports.mkdirpPromise = mkdirpPromise;
     function writeFilePromise(path, data) {
         return new Promise((resolve, reject) => fs_1.default.writeFile(path, data, (err) => (err ? reject(err) : resolve())));
     }
+    exports.writeFilePromise = writeFilePromise;
     function writeFile(path, data) {
         return fs_1.default.writeFileSync(path, data);
     }
+    exports.writeFile = writeFile;
     function readTemplates(keys = [], templatePath) {
         return keys.reduce((ret, key) => {
             ret[key] = fs_1.default.readFileSync(templatePath[key], 'utf8');
             return ret;
         }, {});
     }
+    exports.readTemplates = readTemplates;
     function render(template, data = {}, option = {}) {
         if (option.withDate) {
             data.date = now;
@@ -154,12 +165,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
         }
         return mustache_1.default.render(template, data, option);
     }
+    exports.render = render;
     function objectToTemplateValue(object) {
         if (!lodash_1.default.isObject(object)) {
             return;
         }
         return JSON.stringify(object, null, 2).replace(/"/g, '');
     }
+    exports.objectToTemplateValue = objectToTemplateValue;
     function changeFormat(obj, transformer) {
         if (typeof obj === 'object') {
             if (obj === null) {
@@ -177,6 +190,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             return obj;
         }
     }
+    exports.changeFormat = changeFormat;
     function getIdAttribute(model, name) {
         const { properties } = model;
         if (!properties) {
@@ -194,6 +208,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
         }
         return idAttribute;
     }
+    exports.getIdAttribute = getIdAttribute;
     function getModelDefinitions(spec) {
         return lodash_1.default.reduce(spec.components.schemas, (acc, model) => {
             const modelName = getModelName(model);
@@ -203,22 +218,5 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
             return acc;
         }, {});
     }
-    module.exports = {
-        resolvePath,
-        mkdirpPromise,
-        writeFilePromise,
-        readTemplates,
-        parseSchema,
-        schemaName,
-        applyIf,
-        isFileExistPromise,
-        applyRequired,
-        render,
-        objectToTemplateValue,
-        changeFormat,
-        getIdAttribute,
-        getModelName,
-        writeFile,
-        getModelDefinitions,
-    };
+    exports.getModelDefinitions = getModelDefinitions;
 });

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -1,0 +1,224 @@
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "fs", "path", "mkdirp", "lodash", "mustache", "./spec_file_utils"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    // @ts-nocheck
+    const fs_1 = __importDefault(require("fs"));
+    const path_1 = __importDefault(require("path"));
+    const mkdirp_1 = __importDefault(require("mkdirp"));
+    const lodash_1 = __importDefault(require("lodash"));
+    const mustache_1 = __importDefault(require("mustache"));
+    const spec_file_utils_1 = require("./spec_file_utils");
+    const cwd = process.cwd();
+    const now = new Date();
+    function schemaName(modelName) {
+        return `${modelName}Schema`;
+    }
+    function getModelName(schema) {
+        return schema && schema[spec_file_utils_1.MODEL_DEF_KEY];
+    }
+    function applyIf(data, applyFn = (val) => val) {
+        return data && applyFn(data);
+    }
+    function getRef(schema) {
+        return schema.$ref || schema.$$ref || schema[spec_file_utils_1.ALTERNATIVE_REF_KEY]; // $$ref by swagger-client
+    }
+    function parseOneOf(schema, onSchema) {
+        const { propertyName, mapping } = schema.discriminator;
+        const ret = {
+            propertyName,
+        };
+        const components = schema.oneOf.map((model) => {
+            const modelName = getModelName(model);
+            onSchema({
+                type: 'model',
+                value: model,
+            });
+            return {
+                name: modelName,
+                schemaName: schemaName(modelName),
+                value: model,
+            };
+        });
+        if (mapping) {
+            ret.mapping = lodash_1.default.reduce(mapping, (acc, model, key) => {
+                const { schemaName } = lodash_1.default.find(components, ({ value }) => getRef(value) === model);
+                acc[key] = schemaName;
+                return acc;
+            }, {});
+        }
+        else {
+            ret.mapping = lodash_1.default.reduce(components, (acc, { name, schemaName }) => {
+                acc[name] = schemaName;
+                return acc;
+            }, {});
+        }
+        return ret;
+    }
+    function parseSchema(schema, onSchema) {
+        if (!lodash_1.default.isObject(schema))
+            return;
+        const modelName = getModelName(schema);
+        if (modelName && getIdAttribute(schema)) {
+            return onSchema({
+                type: 'model',
+                value: schema,
+            });
+        }
+        else if (schema.oneOf && schema.discriminator) {
+            return onSchema({
+                type: 'oneOf',
+                value: parseOneOf(schema, onSchema),
+            });
+        }
+        else if (schema.type === 'object') {
+            return applyIf(parseSchema(schema.properties, onSchema));
+        }
+        else if (schema.type === 'array') {
+            return applyIf(parseSchema(schema.items, onSchema), (val) => [val]);
+        }
+        else {
+            const reduced = lodash_1.default.reduce(schema, (ret, val, key) => {
+                const tmp = parseSchema(val, onSchema);
+                if (tmp) {
+                    ret[key] = tmp;
+                }
+                return ret;
+            }, {});
+            if (Object.keys(reduced).length > 0) {
+                return reduced;
+            }
+        }
+    }
+    function isFileExistPromise(path) {
+        return new Promise((resolve, reject) => {
+            fs_1.default.access(path, (err) => {
+                if (!err) {
+                    resolve(true); // file is exist.
+                    return;
+                }
+                if (err.code === 'ENOENT') {
+                    // file is not exist.
+                    resolve(false);
+                }
+                else {
+                    reject(err);
+                }
+            });
+        });
+    }
+    function applyRequired(props, requiredList) {
+        if (!lodash_1.default.isArray(requiredList)) {
+            return props;
+        }
+        return lodash_1.default.reduce(props, (ret, prop, key) => {
+            ret[key] = prop;
+            if (requiredList.includes(key)) {
+                prop.required = true;
+            }
+            return ret;
+        }, {});
+    }
+    function resolvePath(str) {
+        return path_1.default.isAbsolute(str) ? str : path_1.default.join(cwd, str);
+    }
+    function mkdirpPromise(dir) {
+        return mkdirp_1.default(dir);
+    }
+    function writeFilePromise(path, data) {
+        return new Promise((resolve, reject) => fs_1.default.writeFile(path, data, (err) => (err ? reject(err) : resolve())));
+    }
+    function writeFile(path, data) {
+        return fs_1.default.writeFileSync(path, data);
+    }
+    function readTemplates(keys = [], templatePath) {
+        return keys.reduce((ret, key) => {
+            ret[key] = fs_1.default.readFileSync(templatePath[key], 'utf8');
+            return ret;
+        }, {});
+    }
+    function render(template, data = {}, option = {}) {
+        if (option.withDate) {
+            data.date = now;
+            delete option.withDate;
+        }
+        return mustache_1.default.render(template, data, option);
+    }
+    function objectToTemplateValue(object) {
+        if (!lodash_1.default.isObject(object)) {
+            return;
+        }
+        return JSON.stringify(object, null, 2).replace(/"/g, '');
+    }
+    function changeFormat(obj, transformer) {
+        if (typeof obj === 'object') {
+            if (obj === null) {
+                return obj;
+            }
+            const formattedObj = Array.isArray(obj) ? [] : {};
+            const keys = Object.keys(obj);
+            keys.forEach((key) => {
+                const value = obj[key];
+                formattedObj[transformer(key)] = changeFormat(value, transformer);
+            });
+            return formattedObj;
+        }
+        else {
+            return obj;
+        }
+    }
+    function getIdAttribute(model, name) {
+        const { properties } = model;
+        if (!properties) {
+            if (name) {
+                console.warn(`${name} is not model definition.`); // eslint-disable-line no-console
+            }
+            return false;
+        }
+        const idAttribute = model['x-id-attribute'] ? model['x-id-attribute'] : 'id';
+        if (!idAttribute.includes('.') && !properties[idAttribute]) {
+            if (name) {
+                console.warn(`${name} is not generated without id attribute.`); // eslint-disable-line no-console
+            }
+            return false;
+        }
+        return idAttribute;
+    }
+    function getModelDefinitions(spec) {
+        return lodash_1.default.reduce(spec.components.schemas, (acc, model) => {
+            const modelName = getModelName(model);
+            if (modelName) {
+                acc[modelName] = model;
+            }
+            return acc;
+        }, {});
+    }
+    module.exports = {
+        resolvePath,
+        mkdirpPromise,
+        writeFilePromise,
+        readTemplates,
+        parseSchema,
+        schemaName,
+        applyIf,
+        isFileExistPromise,
+        applyRequired,
+        render,
+        objectToTemplateValue,
+        changeFormat,
+        getIdAttribute,
+        getModelName,
+        writeFile,
+        getModelDefinitions,
+    };
+});

--- a/src/tools/action_types_generator.ts
+++ b/src/tools/action_types_generator.ts
@@ -1,5 +1,6 @@
-const path = require('path');
-const { writeFilePromise, readTemplates, render } = require('./utils');
+// @ts-nocheck
+import path from 'path';
+import { writeFilePromise, readTemplates, render } from './utils';
 
 class ActionTypesGenerator {
   constructor({

--- a/src/tools/action_types_generator.ts
+++ b/src/tools/action_types_generator.ts
@@ -2,7 +2,7 @@
 import path from 'path';
 import { writeFilePromise, readTemplates, render } from './utils';
 
-class ActionTypesGenerator {
+export default class ActionTypesGenerator {
   constructor({
     outputPath = '',
     schemasFilePath = '',
@@ -46,5 +46,3 @@ class ActionTypesGenerator {
     return writeFilePromise(path.join(this.outputDir, this.outputFileName), text);
   }
 }
-
-module.exports = ActionTypesGenerator;

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -1,4 +1,4 @@
-class Config {
+export default class Config {
   _config: ConfigObject;
 
   attributeConverter: AttributeConverter;
@@ -83,5 +83,3 @@ class Config {
     };
   }
 }
-
-module.exports = Config;

--- a/src/tools/js_spec_generator.ts
+++ b/src/tools/js_spec_generator.ts
@@ -14,7 +14,7 @@ const UNNECESSARY_PROPS = [
   'x-enum-key-attributes',
 ];
 
-class JsSpecGenerator {
+export default class JsSpecGenerator {
   constructor({ outputPath = '', templatePath, extension = 'js' }) {
     this.outputPath = outputPath;
     this.templatePath = templatePath;
@@ -79,5 +79,3 @@ class JsSpecGenerator {
     }
   }
 }
-
-module.exports = JsSpecGenerator;

--- a/src/tools/js_spec_generator.ts
+++ b/src/tools/js_spec_generator.ts
@@ -1,11 +1,8 @@
-const path = require('path');
-const _ = require('lodash');
-const { writeFilePromise, readTemplates, render } = require('./utils');
-const {
-  walkSchema,
-  MODEL_DEF_KEY,
-  ALTERNATIVE_REF_KEY,
-} = require('../../dist/compiled/spec_file_utils');
+// @ts-nocheck
+import path from 'path';
+import _ from 'lodash';
+import { writeFilePromise, readTemplates, render } from './utils';
+import { walkSchema, MODEL_DEF_KEY, ALTERNATIVE_REF_KEY } from './spec_file_utils';
 
 const UNNECESSARY_PROPS = [
   ALTERNATIVE_REF_KEY,
@@ -68,11 +65,11 @@ class JsSpecGenerator {
     });
 
     function checkRef(targetRef) {
-      // eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [, components, group, name, ...rest] = targetRef.split('/');
       walkSchema(spec[components][group][name], (obj) => {
         if (obj.$ref) {
-          // eslint-disable-next-line no-unused-vars
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const [hash, components, group, name, ...rest] = obj.$ref.split('/');
           const ref = [hash, components, group, name].join('/');
           useRefs[ref] = true;

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -21,7 +21,7 @@ import {
  * モデル定義からモデルファイルを作成
  */
 
-class ModelGenerator {
+export default class ModelGenerator {
   constructor({
     outputDir = '',
     outputBaseDir = '',
@@ -427,5 +427,3 @@ function getDefaults() {
   }
   return this.type === 'string' ? `'${this.default}'` : this.default;
 }
-
-module.exports = ModelGenerator;

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -1,7 +1,8 @@
 /* eslint-disable */
-const _ = require('lodash');
-const path = require('path');
-const {
+// @ts-nocheck
+import _ from 'lodash';
+import path from 'path';
+import {
   parseSchema,
   schemaName,
   render,
@@ -14,7 +15,7 @@ const {
   changeFormat,
   getModelName,
   writeFile,
-} = require('./utils');
+} from './utils';
 
 /**
  * モデル定義からモデルファイルを作成

--- a/src/tools/schema_generator.ts
+++ b/src/tools/schema_generator.ts
@@ -19,7 +19,7 @@ import {
  * content-typeはjsonのみサポート
  */
 
-class SchemaGenerator {
+export default class SchemaGenerator {
   constructor({
     outputPath = '',
     templatePath = {},
@@ -151,5 +151,3 @@ class SchemaGenerator {
     return response.content && response.content['application/json'];
   }
 }
-
-module.exports = SchemaGenerator;

--- a/src/tools/schema_generator.ts
+++ b/src/tools/schema_generator.ts
@@ -1,6 +1,7 @@
-const _ = require('lodash');
-const path = require('path');
-const {
+// @ts-nocheck
+import _ from 'lodash';
+import path from 'path';
+import {
   applyIf,
   schemaName,
   parseSchema,
@@ -11,7 +12,7 @@ const {
   render,
   changeFormat,
   getIdAttribute,
-} = require('./utils');
+} from './utils';
 
 /**
  * レスポンス定義からnormalizr用のschemaを作成

--- a/src/tools/spec_file_utils.ts
+++ b/src/tools/spec_file_utils.ts
@@ -13,8 +13,8 @@ import jsYaml from 'js-yaml';
 import $RefParser from 'json-schema-ref-parser';
 import { OpenAPIV3 } from 'openapi-types';
 
-const ALTERNATIVE_REF_KEY = '__$ref__';
-const MODEL_DEF_KEY = 'x-model-name';
+export const ALTERNATIVE_REF_KEY = '__$ref__';
+export const MODEL_DEF_KEY = 'x-model-name';
 
 /* library alias */
 
@@ -28,16 +28,17 @@ type Model = Schema & {
   [MODEL_DEF_KEY]?: string;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const isOperation = (obj: any): obj is Operation => 'tags' in obj;
 
 const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
 
 // メソッド名の Union String Literal Types = 'get' | 'put' | ... | 'trace';
-type MethodName = (typeof methodNames)[number];
+type MethodName = typeof methodNames[number];
 
 const isMethodName = (str: string): str is MethodName => methodNames.includes(str as any);
 
-function readSpecFilePromise(path: string, options: OptionObject = {}) {
+export function readSpecFilePromise(path: string, options: OptionObject = {}) {
   const data = fs.readFileSync(path, 'utf8');
   const original: Document = jsYaml.safeLoad(data);
   if (!options.dereference) return Promise.resolve(original);
@@ -53,7 +54,8 @@ function readSpecFilePromise(path: string, options: OptionObject = {}) {
   });
 }
 
-function walkSchema(spec: any, callback: (s: any) => void = noop): any {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function walkSchema(spec: any, callback: (s: any) => void = noop): any {
   if (isArray(spec)) {
     return spec.forEach((item) => walkSchema(item, callback));
   } else if (isObject(spec)) {
@@ -82,7 +84,7 @@ function applyAlternativeRef(spec: Document) {
   return spec;
 }
 
-function convertToLocalDefinition(spec: Document) {
+export function convertToLocalDefinition(spec: Document) {
   walkSchema(spec, (obj) => {
     if (obj.$ref) {
       const index = obj.$ref.indexOf('#');
@@ -92,7 +94,7 @@ function convertToLocalDefinition(spec: Document) {
   return spec;
 }
 
-function getPreparedSpecFilePaths(specFiles: string[], tags: string[] = []) {
+export function getPreparedSpecFilePaths(specFiles: string[], tags: string[] = []) {
   const readFiles: { [key: string]: boolean } = {};
   const tmpDir = fs.mkdtempSync(
     path.join(fs.realpathSync(os.tmpdir()), '__openapi_to_normalizr__'),
@@ -154,12 +156,3 @@ function getPreparedSpecFilePaths(specFiles: string[], tags: string[] = []) {
     }, []);
   }
 }
-
-module.exports = {
-  readSpecFilePromise,
-  getPreparedSpecFilePaths,
-  convertToLocalDefinition,
-  walkSchema,
-  ALTERNATIVE_REF_KEY,
-  MODEL_DEF_KEY,
-};

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -9,15 +9,15 @@ import { MODEL_DEF_KEY, ALTERNATIVE_REF_KEY } from './spec_file_utils';
 const cwd = process.cwd();
 const now = new Date();
 
-function schemaName(modelName) {
+export function schemaName(modelName) {
   return `${modelName}Schema`;
 }
 
-function getModelName(schema) {
+export function getModelName(schema) {
   return schema && schema[MODEL_DEF_KEY];
 }
 
-function applyIf(data, applyFn = (val) => val) {
+export function applyIf(data, applyFn = (val) => val) {
   return data && applyFn(data);
 }
 
@@ -66,7 +66,7 @@ function parseOneOf(schema, onSchema) {
   return ret;
 }
 
-function parseSchema(schema, onSchema) {
+export function parseSchema(schema, onSchema) {
   if (!_.isObject(schema)) return;
 
   const modelName = getModelName(schema);
@@ -102,7 +102,7 @@ function parseSchema(schema, onSchema) {
   }
 }
 
-function isFileExistPromise(path) {
+export function isFileExistPromise(path) {
   return new Promise((resolve, reject) => {
     fs.access(path, (err) => {
       if (!err) {
@@ -119,7 +119,7 @@ function isFileExistPromise(path) {
   });
 }
 
-function applyRequired(props, requiredList) {
+export function applyRequired(props, requiredList) {
   if (!_.isArray(requiredList)) {
     return props;
   }
@@ -136,32 +136,32 @@ function applyRequired(props, requiredList) {
   );
 }
 
-function resolvePath(str) {
+export function resolvePath(str) {
   return path.isAbsolute(str) ? str : path.join(cwd, str);
 }
 
-function mkdirpPromise(dir) {
+export function mkdirpPromise(dir) {
   return mkdirp(dir);
 }
 
-function writeFilePromise(path, data) {
+export function writeFilePromise(path, data) {
   return new Promise((resolve, reject) =>
     fs.writeFile(path, data, (err) => (err ? reject(err) : resolve())),
   );
 }
 
-function writeFile(path, data) {
+export function writeFile(path, data) {
   return fs.writeFileSync(path, data);
 }
 
-function readTemplates(keys = [], templatePath) {
+export function readTemplates(keys = [], templatePath) {
   return keys.reduce((ret, key) => {
     ret[key] = fs.readFileSync(templatePath[key], 'utf8');
     return ret;
   }, {});
 }
 
-function render(template, data = {}, option = {}) {
+export function render(template, data = {}, option = {}) {
   if (option.withDate) {
     data.date = now;
     delete option.withDate;
@@ -169,14 +169,14 @@ function render(template, data = {}, option = {}) {
   return mustache.render(template, data, option);
 }
 
-function objectToTemplateValue(object) {
+export function objectToTemplateValue(object) {
   if (!_.isObject(object)) {
     return;
   }
   return JSON.stringify(object, null, 2).replace(/"/g, '');
 }
 
-function changeFormat(obj, transformer) {
+export function changeFormat(obj, transformer) {
   if (typeof obj === 'object') {
     if (obj === null) {
       return obj;
@@ -193,7 +193,7 @@ function changeFormat(obj, transformer) {
   }
 }
 
-function getIdAttribute(model, name) {
+export function getIdAttribute(model, name) {
   const { properties } = model;
   if (!properties) {
     if (name) {
@@ -211,7 +211,7 @@ function getIdAttribute(model, name) {
   return idAttribute;
 }
 
-function getModelDefinitions(spec) {
+export function getModelDefinitions(spec) {
   return _.reduce(
     spec.components.schemas,
     (acc, model) => {
@@ -224,22 +224,3 @@ function getModelDefinitions(spec) {
     {},
   );
 }
-
-module.exports = {
-  resolvePath,
-  mkdirpPromise,
-  writeFilePromise,
-  readTemplates,
-  parseSchema,
-  schemaName,
-  applyIf,
-  isFileExistPromise,
-  applyRequired,
-  render,
-  objectToTemplateValue,
-  changeFormat,
-  getIdAttribute,
-  getModelName,
-  writeFile,
-  getModelDefinitions,
-};

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,11 +1,13 @@
-const fs = require('fs');
-const path = require('path');
-const mkdirp = require('mkdirp');
-const _ = require('lodash');
-const mustache = require('mustache');
+// @ts-nocheck
+import fs from 'fs';
+import path from 'path';
+import mkdirp from 'mkdirp';
+import _ from 'lodash';
+import mustache from 'mustache';
+import { MODEL_DEF_KEY, ALTERNATIVE_REF_KEY } from './spec_file_utils';
+
 const cwd = process.cwd();
 const now = new Date();
-const { MODEL_DEF_KEY, ALTERNATIVE_REF_KEY } = require('../../dist/compiled/spec_file_utils');
 
 function schemaName(modelName) {
   return `${modelName}Schema`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "ESNEXT",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "umd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2015", "es2015.iterable"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "target": "ESNEXT",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "umd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2015", "es2015.iterable"],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
一旦tools下のJSを`// @ts-nocheck`（ファイル全体の型チェックを無視する）をつけて、全てTSにする。
当初は一つずつ、JSをTSに置き換えていく予定だったが、utils.jsがいろいろなところで使われており、型情報が追いづらすぎて断念。
一旦TSにしてしまった方がエディタの補完の恩恵を受けられるので、その路線に切り替えていく。

今回の作業内容は以下
- JSファイルをTSファイルにリネームし、先頭に`// @ts-nocheck`をつける
- `module.exports`でexportするのを廃止
