### PR TITLE
Fix breaked command

### DIFF
--- a/bin/generateschemas
+++ b/bin/generateschemas
@@ -7,7 +7,7 @@
 const path = require('path');
 const program = require('commander');
 const _ = require('lodash');
-const main = require('../dist/compiled/main');
+const main = require('../dist/compiled/main').default;
 
 program
   .option('-c, --config <configPath>', 'config path')
@@ -15,7 +15,7 @@ program
   .parse(process.argv);
 const specFiles = program.args;
 
-const userConfig = program.config ? require(program.config) : {};
+const userConfig = program.config ? require(path.join(process.cwd(), program.config)) : {};
 const defaultConfig = require(path.join(__dirname, '../config/parser-config-default.js'));
 const config = _.merge({}, defaultConfig, userConfig);
 console.info(`parse file: ${specFiles}`);

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "mock": "json-server --watch examples/db.json --port 10010",
     "prepare:mock": "cd examples/petstore && yarn",
     "serve": "bin/serve examples ",
-    "test": "jest src/lib spec && yarn check:typescript",
+    "test": "yarn check:typescript && jest src/lib spec",
     "jest": "jest",
     "lint": "yarn check:prettier && yarn eslint && yarn speclint",
     "speclint": "find spec examples -name '*.yml' | xargs -I{} yarn speccy {}",


### PR DESCRIPTION
## `bin/generateschemas`
  - configファイル指定での挙動が以前のバージョンと変わっていたため修正
  - requireの指定ミス修正

## `yarn test`
  - `yarn test -u ` のように利用できないため順番を入れ替え