### PR TITLE
一時領域への退避をやめる

### DIFF
--- a/dist/compiled/main.js
+++ b/dist/compiled/main.js
@@ -17,7 +17,8 @@ const config_1 = __importDefault(require("./config"));
 async function main(specFiles, c) {
     const config = new config_1.default(c);
     const spec = spec_file_utils_1.getPreparedSpec(specFiles, config.tags);
-    const copiedSpec = JSON.stringify(spec); // dereferenceが内部状態を変えてしまうためcopy
+    // dereferenceが内部状態を変えてしまうためcopy
+    const copiedSpec = JSON.parse(JSON.stringify(spec));
     await spec_file_utils_1.dereferenceSchema(spec)
         .then((spec) => {
         let actionTypesGenerator, modelGenerator, schemaGenerator;
@@ -56,7 +57,7 @@ async function main(specFiles, c) {
             throw e;
         });
     })
-        .then(() => new js_spec_generator_1.default(config.formatForJsSpecGenerator()).write(JSON.parse(copiedSpec)))
+        .then(() => new js_spec_generator_1.default(config.formatForJsSpecGenerator()).write(copiedSpec))
         .catch((e) => {
         console.error(`Failed: ${e}`);
         throw e;

--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -156,23 +156,15 @@ class ModelGenerator {
         });
     }
     getEnumConstantName(enumName, propertyName) {
-        const convertedName = lodash_1.default.upperCase(propertyName)
-            .split(' ')
-            .join('_');
-        const convertedkey = lodash_1.default.upperCase(enumName)
-            .split(' ')
-            .join('_');
+        const convertedName = lodash_1.default.upperCase(propertyName).split(' ').join('_');
+        const convertedkey = lodash_1.default.upperCase(enumName).split(' ').join('_');
         // enumNameがマイナスの数値の時
         const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `MINUS_${convertedkey}` : convertedkey;
         return `${convertedName}_${resolvedkey}`;
     }
     getEnumLiteralTypeName(enumName, propertyName) {
-        const convertedName = lodash_1.default.startCase(propertyName)
-            .split(' ')
-            .join('');
-        const convertedkey = lodash_1.default.startCase(enumName)
-            .split(' ')
-            .join('');
+        const convertedName = lodash_1.default.startCase(propertyName).split(' ').join('');
+        const convertedkey = lodash_1.default.startCase(enumName).split(' ').join('');
         // enumNameがマイナスの数値の時
         const resolvedkey = typeof enumName === 'number' && enumName < 0 ? `Minus${convertedkey}` : convertedkey;
         return `${convertedName}${resolvedkey}`;

--- a/dist/compiled/spec_file_utils.js
+++ b/dist/compiled/spec_file_utils.js
@@ -46,7 +46,7 @@ function getRefFilesPath(spec) {
     });
     return paths;
 }
-function getPreparedSpec(specFiles, tags = []) {
+function getPreparedSpec(specFiles = [], tags = []) {
     const readFiles = {};
     const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
     return merge_1.default({}, ...specFiles.concat(allFiles).map((p) => {
@@ -55,7 +55,8 @@ function getPreparedSpec(specFiles, tags = []) {
             removeUnusableOperation(spec);
         }
         else {
-            delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
+            // 指定されたspecファイル以外のpath情報は不要
+            delete spec.paths;
         }
         applyAlternativeRef(spec);
         const schemas = spec.components && spec.components.schemas;

--- a/dist/compiled/spec_file_utils.js
+++ b/dist/compiled/spec_file_utils.js
@@ -4,9 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const fs_1 = __importDefault(require("fs"));
-const os_1 = __importDefault(require("os"));
 const path_1 = __importDefault(require("path"));
-const mkdirp_1 = __importDefault(require("mkdirp"));
 const merge_1 = __importDefault(require("lodash/merge"));
 const noop_1 = __importDefault(require("lodash/noop"));
 const isArray_1 = __importDefault(require("lodash/isArray"));
@@ -22,23 +20,10 @@ exports.MODEL_DEF_KEY = 'x-model-name';
 const isOperation = (obj) => 'tags' in obj;
 const methodNames = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 const isMethodName = (str) => methodNames.includes(str);
-function readSpecFilePromise(path, options = {}) {
-    const data = fs_1.default.readFileSync(path, 'utf8');
-    const original = js_yaml_1.default.safeLoad(data);
-    if (!options.dereference)
-        return Promise.resolve(original);
-    return new Promise((resolve, reject) => {
-        json_schema_ref_parser_1.default.dereference(path, (err, schema) => {
-            schema = merge_1.default(original, schema);
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(schema);
-        });
-    });
+function dereferenceSchema(spec) {
+    return json_schema_ref_parser_1.default.dereference(spec);
 }
-exports.readSpecFilePromise = readSpecFilePromise;
+exports.dereferenceSchema = dereferenceSchema;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function walkSchema(spec, callback = noop_1.default) {
     if (isArray_1.default(spec)) {
@@ -61,31 +46,10 @@ function getRefFilesPath(spec) {
     });
     return paths;
 }
-function applyAlternativeRef(spec) {
-    walkSchema(spec, (obj) => {
-        if (obj.$ref) {
-            obj[exports.ALTERNATIVE_REF_KEY] = obj.$ref;
-        }
-    });
-    return spec;
-}
-function convertToLocalDefinition(spec) {
-    walkSchema(spec, (obj) => {
-        if (obj.$ref) {
-            const index = obj.$ref.indexOf('#');
-            obj.$ref = obj.$ref.slice(index);
-        }
-    });
-    return spec;
-}
-exports.convertToLocalDefinition = convertToLocalDefinition;
-function getPreparedSpecFilePaths(specFiles, tags = []) {
+function getPreparedSpec(specFiles, tags = []) {
     const readFiles = {};
-    const tmpDir = fs_1.default.mkdtempSync(path_1.default.join(fs_1.default.realpathSync(os_1.default.tmpdir()), '__openapi_to_normalizr__'));
     const allFiles = uniq_1.default(getAllRelatedFiles(specFiles));
-    return specFiles.concat(allFiles).map((p) => {
-        const target = path_1.default.join(tmpDir, p);
-        mkdirp_1.default.sync(path_1.default.dirname(target));
+    return merge_1.default({}, ...specFiles.concat(allFiles).map((p) => {
         const spec = js_yaml_1.default.safeLoad(fs_1.default.readFileSync(p).toString());
         if (specFiles.includes(p)) {
             removeUnusableOperation(spec);
@@ -100,9 +64,8 @@ function getPreparedSpecFilePaths(specFiles, tags = []) {
                 model[exports.MODEL_DEF_KEY] = name;
             });
         }
-        fs_1.default.writeFileSync(target, js_yaml_1.default.safeDump(spec));
-        return target;
-    });
+        return spec;
+    }));
     function isUsableOperation(operationTags) {
         if (tags.length === 0)
             return true;
@@ -135,5 +98,16 @@ function getPreparedSpecFilePaths(specFiles, tags = []) {
             return acc.concat(relatedFilesPaths);
         }, []);
     }
+    function applyAlternativeRef(spec) {
+        walkSchema(spec, (obj) => {
+            if (obj.$ref) {
+                // mergeされるので内部refに変換
+                const index = obj.$ref.indexOf('#');
+                obj.$ref = obj.$ref.slice(index);
+                obj[exports.ALTERNATIVE_REF_KEY] = obj.$ref;
+            }
+        });
+        return spec;
+    }
 }
-exports.getPreparedSpecFilePaths = getPreparedSpecFilePaths;
+exports.getPreparedSpec = getPreparedSpec;

--- a/src/tools/main.ts
+++ b/src/tools/main.ts
@@ -3,11 +3,7 @@ import path from 'path';
 import Swagger from 'swagger-client';
 import _ from 'lodash';
 import { mkdirpPromise, getModelDefinitions } from './utils';
-import {
-  readSpecFilePromise,
-  getPreparedSpecFilePaths,
-  convertToLocalDefinition,
-} from './spec_file_utils';
+import { getPreparedSpec, dereferenceSchema } from './spec_file_utils';
 import ModelGenerator from './model_generator';
 import SchemaGenerator from './schema_generator';
 import ActionTypesGenerator from './action_types_generator';
@@ -16,18 +12,11 @@ import Config from './config';
 
 export default async function main(specFiles, c) {
   const config = new Config(c);
-  const filePaths = getPreparedSpecFilePaths(specFiles, config.tags);
+  const spec = getPreparedSpec(specFiles, config.tags);
+  const copiedSpec = JSON.stringify(spec); // dereferenceが内部状態を変えてしまうためcopy
 
-  await Promise.all(
-    filePaths.map((file) =>
-      readSpecFilePromise(file, {
-        dereference: true,
-      }),
-    ),
-  )
-    .then((schemas) => {
-      const spec = _.merge(...schemas);
-
+  await dereferenceSchema(spec)
+    .then((spec) => {
       let actionTypesGenerator, modelGenerator, schemaGenerator;
       const [actionsDir, schemasDir, specDir] = ['actions', 'schemas', 'jsSpec'].map((key) =>
         path.dirname(config.outputPath[key]),
@@ -76,19 +65,9 @@ export default async function main(specFiles, c) {
           throw e;
         });
     })
-    .then(() => {
-      // no need dereference for js spec file
-      return Promise.all(
-        filePaths.map((file) =>
-          readSpecFilePromise(file, {
-            dereference: false,
-          }),
-        ),
-      ).then((schemas) => {
-        const spec = convertToLocalDefinition(_.merge(...schemas));
-        return new JsSpecGenerator(config.formatForJsSpecGenerator()).write(spec);
-      });
-    })
+    .then(() =>
+      new JsSpecGenerator(config.formatForJsSpecGenerator()).write(JSON.parse(copiedSpec)),
+    )
     .catch((e) => {
       console.error(`Failed: ${e}`);
       throw e;

--- a/src/tools/main.ts
+++ b/src/tools/main.ts
@@ -13,7 +13,8 @@ import Config from './config';
 export default async function main(specFiles, c) {
   const config = new Config(c);
   const spec = getPreparedSpec(specFiles, config.tags);
-  const copiedSpec = JSON.stringify(spec); // dereferenceが内部状態を変えてしまうためcopy
+  // dereferenceが内部状態を変えてしまうためcopy
+  const copiedSpec = JSON.parse(JSON.stringify(spec));
 
   await dereferenceSchema(spec)
     .then((spec) => {
@@ -65,9 +66,7 @@ export default async function main(specFiles, c) {
           throw e;
         });
     })
-    .then(() =>
-      new JsSpecGenerator(config.formatForJsSpecGenerator()).write(JSON.parse(copiedSpec)),
-    )
+    .then(() => new JsSpecGenerator(config.formatForJsSpecGenerator()).write(copiedSpec))
     .catch((e) => {
       console.error(`Failed: ${e}`);
       throw e;

--- a/src/tools/spec_file_utils.ts
+++ b/src/tools/spec_file_utils.ts
@@ -72,7 +72,8 @@ export function getPreparedSpec(specFiles: string[] = [], tags: string[] = []) {
       if (specFiles.includes(p)) {
         removeUnusableOperation(spec);
       } else {
-        delete spec.paths; // 指定されたspecファイル以外のpath情報は不要
+        // 指定されたspecファイル以外のpath情報は不要
+        delete spec.paths;
       }
       applyAlternativeRef(spec);
       const schemas = spec.components && spec.components.schemas;

--- a/src/tools/spec_file_utils.ts
+++ b/src/tools/spec_file_utils.ts
@@ -61,7 +61,7 @@ function getRefFilesPath(spec: Document) {
   return paths;
 }
 
-export function getPreparedSpec(specFiles: string[], tags: string[] = []) {
+export function getPreparedSpec(specFiles: string[] = [], tags: string[] = []) {
   const readFiles: { [key: string]: boolean } = {};
   const allFiles = uniq(getAllRelatedFiles(specFiles));
 


### PR DESCRIPTION
`dereference` がスキーマを直接読める(ようになったっぽい？) ので一時ファイルが不要にできる。