### PR TITLE
Use ts-expect-error instead of ts-ignore

### DIFF
--- a/spec/command.test.ts
+++ b/spec/command.test.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error
 import defaultConfig from '../config/parser-config-default';
 import rimraf from 'rimraf';
 import fs from 'fs';

--- a/src/lib/entities-reducer.test.ts
+++ b/src/lib/entities-reducer.test.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-// @ts-ignore
 import { createReducer } from './entities-reducer';
 import { Map, Record } from 'immutable';
 

--- a/src/lib/redux-open-api.test.ts
+++ b/src/lib/redux-open-api.test.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import nock from 'nock';
-// @ts-ignore
 import createMiddleware, { HttpClient } from './redux-open-api';
 import jsYaml from 'js-yaml';
 import noop from 'lodash/noop';

--- a/src/tools/main.ts
+++ b/src/tools/main.ts
@@ -88,16 +88,16 @@ export default async function main(specFiles: TODO, c: TODO) {
           console.warn(`not processed. path:${path}, method:${method}`);
           return;
         }
-        // @ts-ignore
+        // @ts-expect-error
         if (operation.operationId) {
           console.info(
-            // @ts-ignore
+            // @ts-expect-error
             `no use specified operationId. path:${path}, method:${method}, operationId:${operation.operationId}`,
           );
-          // @ts-ignore
+          // @ts-expect-error
           delete operation.operationId;
         }
-        // @ts-ignore
+        // @ts-expect-error
         const response = operation.responses;
         const id = opId(operation, path, method);
         onResponses.forEach((onResponse: TODO) =>

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -154,7 +154,7 @@ export default class ModelGenerator {
       const importList: TODO[] = [];
       const oneOfs: TODO[] = [];
       let oneOfsCounter = 1;
-      // @ts-ignore
+      // @ts-expect-error
       const dependencySchema = parseSchema(properties, ({ type, value }) => {
         if (type === 'model') {
           const modelName = getModelName(value);
@@ -230,7 +230,7 @@ export default class ModelGenerator {
         enumType: this._getEnumTypes(prop.type),
         items: prop.items,
       };
-      // @ts-ignore
+      // @ts-expect-error
       return this.constructor.templatePropNames.reduce(
         (ret: { [key: string]: TODO }, key: TODO) => {
           ret[key] = ret[key] || properties[name][key];
@@ -397,7 +397,7 @@ export default class ModelGenerator {
 }
 
 function getPropTypes() {
-  // @ts-ignore
+  // @ts-expect-error
   return _getPropTypes(this.type, this.enum, this.enumObjects);
 }
 
@@ -424,7 +424,7 @@ function _getPropTypes(type: TODO, enums?: TODO[], enumObjects?: TODO[]) {
 }
 
 function getTypeScriptTypes() {
-  // @ts-ignore
+  // @ts-expect-error
   return _getTypeScriptTypes(this.type, this.enumObjects);
 }
 
@@ -447,18 +447,18 @@ function _getTypeScriptTypes(type: TODO, enumObjects: TODO[]) {
 }
 
 function getDefaults() {
-  // @ts-ignore
+  // @ts-expect-error
   if (_.isUndefined(this.default)) {
     return 'undefined';
   }
-  // @ts-ignore
+  // @ts-expect-error
   if (this.enumObjects) {
-    // @ts-ignore
+    // @ts-expect-error
     for (const enumObject of this.enumObjects) {
-      // @ts-ignore
+      // @ts-expect-error
       if (enumObject.value === this.default) return enumObject.name;
     }
   }
-  // @ts-ignore
+  // @ts-expect-error
   return this.type === 'string' ? `'${this.default}'` : this.default;
 }

--- a/src/tools/schema_generator.ts
+++ b/src/tools/schema_generator.ts
@@ -129,11 +129,11 @@ export default class SchemaGenerator {
    * パース情報とテンプレートからschema.jsとmodels/index.js書き出し
    */
   write() {
-    // @ts-ignore
+    // @ts-expect-error
     return Promise.all([
       this._writeSchemaFile(),
       ...this.importModels.map(({ modelName, model }) =>
-        // @ts-ignore
+        // @ts-expect-error
         this.modelGenerator.writeModel(model, modelName),
       ),
     ]).then(() => {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -74,19 +74,19 @@ export function parseSchema(schema: TODO, onSchema: TODO): TODO {
       type: 'model',
       value: schema,
     });
-    // @ts-ignore
+    // @ts-expect-error
   } else if (schema.oneOf && schema.discriminator) {
     return onSchema({
       type: 'oneOf',
       value: parseOneOf(schema, onSchema),
     });
-    // @ts-ignore
+    // @ts-expect-error
   } else if (schema.type === 'object') {
-    // @ts-ignore
+    // @ts-expect-error
     return applyIf(parseSchema(schema.properties, onSchema));
-    // @ts-ignore
+    // @ts-expect-error
   } else if (schema.type === 'array') {
-    // @ts-ignore
+    // @ts-expect-error
     return applyIf(parseSchema(schema.items, onSchema), (val) => [val]);
   } else {
     const reduced = _.reduce(


### PR DESCRIPTION
TypeScript v3.9.2で`// @ts-expect-error`が導入された。

これまで使っていた`// @ts-ignore`は次の行に型エラーがあってもなくても無視するが、`// @ts-expect-error`はエラーがないと怒る。

つまりコードを修正する中で不要になった`// @ts-expect-error`を素早く見つけ、取り除くことができる。

のでこれを使う。