### PR TITLE
compressed sizeをチェックするGitHub Actionsを追加

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,15 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          build-script: 'build:dist'
+          pattern: './dist/**/*.js'

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "main": "dist/index.js",
   "repository": "eightcard/openapi-to-normalizr",
   "scripts": {
-    "build:dist": "yarn eslint && yarn test && yarn build:dist:lib && yarn build:dist:tools",
+    "build:dist": "yarn build:dist:lib && yarn build:dist:tools",
     "build:dist:lib": "babel -d dist --env-name=development --extensions '.ts' src/lib/**/*[^test].ts",
     "build:dist:tools": "babel -d dist/compiled --env-name=development --extensions '.ts' src/tools/**/*.ts",
     "build:sample": "webpack --config examples/webpack.config.babel.js --progress",


### PR DESCRIPTION
### 作業

package.jsonの"build:dist"scriptを使ってサイズ比較をする
build:distでeslintとtestをするのをやめる（そもそもCIで両方チェックしているので別だししても良いはず）