### PR TITLE
Add timeout

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
デフォルトだと６時間でタイムアウトなんで転ばぬ先の杖的に設定しておくと良いです.
実行履歴を見たところ1分ちょいなので10分を超える様ならタイムアウトで良いかと.

- [Workflow syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes)

> jobs.<job_id>.timeout-minutes
The maximum number of minutes to let a job run before GitHub automatically cancels it. Default: 360