### PR TITLE
@ts-expect-errorの理由を書く

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -273,7 +273,6 @@ module.exports = {
       parserOptions: {
         sourceType: 'module',
         ecmaVersion: 2019,
-        project: './tsconfig.json',
       },
       rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/spec/command.test.ts
+++ b/spec/command.test.ts
@@ -1,4 +1,4 @@
-// @ts-expect-error
+// @ts-expect-error configファイルの想定する型がまだわかりきってない。書くならindex.d.tsに
 import defaultConfig from '../config/parser-config-default';
 import rimraf from 'rimraf';
 import fs from 'fs';

--- a/src/lib/redux-open-api.test.ts
+++ b/src/lib/redux-open-api.test.ts
@@ -11,7 +11,6 @@ const spec = jsYaml.safeLoad(fs.readFileSync('examples/petstore.v3.yml', 'utf8')
 describe('middleware', () => {
   const nextFunction = jest.fn();
   const subject = (...args: TODO) => {
-    // @ts-expect-error
     return createMiddleware(spec).then((middleware: TODO) => {
       return middleware()(nextFunction)(...args);
     });

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -13,7 +13,7 @@ function isOpenApiAction(action: TODO) {
 
 export const HttpClient = Swagger.http;
 
-export default (spec: TODO, httpOptions: TODO): TODO => {
+export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
   return Swagger({
     spec,
   }).then(({ apis }: { apis: TODO }) => {

--- a/src/tools/main.ts
+++ b/src/tools/main.ts
@@ -88,16 +88,16 @@ export default async function main(specFiles: TODO, c: TODO) {
           console.warn(`not processed. path:${path}, method:${method}`);
           return;
         }
-        // @ts-expect-error
-        if (operation.operationId) {
+        // @ts-expect-error operationIdがあると認識されていない
+        const operationId = operation.operationId;
+        if (operationId) {
           console.info(
-            // @ts-expect-error
-            `no use specified operationId. path:${path}, method:${method}, operationId:${operation.operationId}`,
+            `no use specified operationId. path:${path}, method:${method}, operationId:${operationId}`,
           );
-          // @ts-expect-error
+          // @ts-expect-error operationIdがあると認識されていない
           delete operation.operationId;
         }
-        // @ts-expect-error
+        // @ts-expect-error responsesがあると認識されていない
         const response = operation.responses;
         const id = opId(operation, path, method);
         onResponses.forEach((onResponse: TODO) =>

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -158,7 +158,7 @@ export default class ModelGenerator {
       const importList: TODO[] = [];
       const oneOfs: TODO[] = [];
       let oneOfsCounter = 1;
-      // @ts-expect-error
+      // @ts-expect-error バインド要素 'type', 'value' には暗黙的に 'any' 型が含まれます。
       const dependencySchema = parseSchema(properties, ({ type, value }) => {
         if (type === 'model') {
           const modelName = getModelName(value);
@@ -236,7 +236,7 @@ export default class ModelGenerator {
         enumType: this._getEnumTypes(prop.type),
         items: prop.items,
       };
-      // @ts-expect-error
+      // @ts-expect-error プロパティ 'templatePropNames' は型 'Function' に存在しません。
       return this.constructor.templatePropNames.reduce(
         (ret: { [key: string]: TODO }, key: TODO) => {
           ret[key] = ret[key] || properties[name][key];
@@ -405,7 +405,7 @@ export default class ModelGenerator {
 }
 
 function getPropTypes() {
-  // @ts-expect-error
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
   return _getPropTypes(this.type, this.enum, this.enumObjects);
 }
 
@@ -432,7 +432,7 @@ function _getPropTypes(type: TODO, enums?: TODO[], enumObjects?: TODO[]) {
 }
 
 function getTypeScriptTypes() {
-  // @ts-expect-error
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
   return _getTypeScriptTypes(this.type, this.enumObjects);
 }
 
@@ -455,18 +455,18 @@ function _getTypeScriptTypes(type: TODO, enumObjects: TODO[]) {
 }
 
 function getDefaults() {
-  // @ts-expect-error
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
   if (_.isUndefined(this.default)) {
     return 'undefined';
   }
-  // @ts-expect-error
-  if (this.enumObjects) {
-    // @ts-expect-error
-    for (const enumObject of this.enumObjects) {
-      // @ts-expect-error
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
+  const enumObjects = this.enumObjects;
+  if (enumObjects) {
+    for (const enumObject of enumObjects) {
+      // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
       if (enumObject.value === this.default) return enumObject.name;
     }
   }
-  // @ts-expect-error
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
   return this.type === 'string' ? `'${this.default}'` : this.default;
 }

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -89,11 +89,13 @@ export default class ModelGenerator {
     const { properties } = model; // dereferenced
     const fileName = _.snakeCase(name);
     const idAttribute = getIdAttribute(model, name);
-    if (!idAttribute) return;
+    if (!idAttribute) return Promise.reject('idAttribute does not exists');
     // requiredはモデル定義のものを使う
     const required = this.definitions[name] && this.definitions[name].required;
 
-    if (this._modelNameList.includes(name)) return;
+    if (this._modelNameList.includes(name)) {
+      return Promise.reject('_modelNameList does not includes modelName');
+    }
     this._modelNameList.push(name);
 
     return this._renderBaseModel(name, applyRequired(properties, required), idAttribute).then(

--- a/src/tools/schema_generator.ts
+++ b/src/tools/schema_generator.ts
@@ -43,7 +43,7 @@ export default class SchemaGenerator {
   parsedObjects: { [key: string]: TODO };
 
   _importModels: {
-    modelName: string | undefined;
+    modelName?: string;
     model: TODO;
   }[];
 
@@ -129,11 +129,10 @@ export default class SchemaGenerator {
    * パース情報とテンプレートからschema.jsとmodels/index.js書き出し
    */
   write() {
-    // @ts-expect-error
-    return Promise.all([
+    return Promise.all<void | string>([
       this._writeSchemaFile(),
       ...this.importModels.map(({ modelName, model }) =>
-        // @ts-expect-error
+        // @ts-expect-error utilsのgetModelNameで生成されるmodelNameがundefinedの可能性がある
         this.modelGenerator.writeModel(model, modelName),
       ),
     ]).then(() => {
@@ -149,7 +148,7 @@ export default class SchemaGenerator {
       }),
     );
     const { schema, head, oneOf } = this.templates;
-    if (!schema || !head || !oneOf) return;
+    if (!schema || !head || !oneOf) return Promise.reject();
     const text = render(
       schema,
       {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -74,19 +74,19 @@ export function parseSchema(schema: TODO, onSchema: TODO): TODO {
       type: 'model',
       value: schema,
     });
-    // @ts-expect-error
+    // @ts-expect-error oneOfやdiscriminatorがあると認識されていない
   } else if (schema.oneOf && schema.discriminator) {
     return onSchema({
       type: 'oneOf',
       value: parseOneOf(schema, onSchema),
     });
-    // @ts-expect-error
+    // @ts-expect-error typeがあると認識されていない
   } else if (schema.type === 'object') {
-    // @ts-expect-error
+    // @ts-expect-error propertiesがあると認識されていない
     return applyIf(parseSchema(schema.properties, onSchema));
-    // @ts-expect-error
+    // @ts-expect-error typeがあると認識されていない
   } else if (schema.type === 'array') {
-    // @ts-expect-error
+    // @ts-expect-error itemsがあると認識されていない
     return applyIf(parseSchema(schema.items, onSchema), (val) => [val]);
   } else {
     const reduced = _.reduce(

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -71,8 +71,8 @@ export default class {{name}} extends Record(defaultValues) {
 {{#alias}}
   // created by 'x-attribute-as'
   get {{&alias}}() {
-{{#useTypeScript}}    // @ts-expect-error generated from API definition file{{/useTypeScript}}
-    return this.get('{{&alias}}', this.{{name}});
+{{#useTypeScript}}    // @ts-expect-error generated from API definition file
+{{/useTypeScript}}    return this.get('{{&alias}}', this.{{name}});
   }
 {{/alias}}
 {{/props}}

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -71,7 +71,7 @@ export default class {{name}} extends Record(defaultValues) {
 {{#alias}}
   // created by 'x-attribute-as'
   get {{&alias}}() {
-{{#useTypeScript}}    // @ts-expect-error{{/useTypeScript}}
+{{#useTypeScript}}    // @ts-expect-error generated from API definition file{{/useTypeScript}}
     return this.get('{{&alias}}', this.{{name}});
   }
 {{/alias}}


### PR DESCRIPTION
// @ts-expect-error 使う場合は理由を述べよとESLintに言われたので書く。

Include a description after the "// @ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.eslint@typescript-eslint/ban-ts-comment

基本的にはエラーを書いたが、直せそうなところは一部直した