### PR TITLE
Add nullable attribute to property data for generating model

### DIFF
--- a/dist/compiled/config.js
+++ b/dist/compiled/config.js
@@ -23,6 +23,26 @@ var Config = /*#__PURE__*/function () {
   }
 
   _createClass(Config, [{
+    key: "tags",
+    get: function get() {
+      return this._config.tags;
+    }
+  }, {
+    key: "outputPath",
+    get: function get() {
+      return this._config.outputPath;
+    }
+  }, {
+    key: "useTypeScript",
+    get: function get() {
+      return this._config.useTypeScript;
+    }
+  }, {
+    key: "extension",
+    get: function get() {
+      return this._config.useTypeScript ? 'ts' : 'js';
+    }
+  }, {
     key: "formatForModelGenerator",
     value: function formatForModelGenerator() {
       var _this$_config = this._config,
@@ -82,26 +102,6 @@ var Config = /*#__PURE__*/function () {
         outputPath: outputPath.jsSpec,
         extension: this.extension
       };
-    }
-  }, {
-    key: "tags",
-    get: function get() {
-      return this._config.tags;
-    }
-  }, {
-    key: "outputPath",
-    get: function get() {
-      return this._config.outputPath;
-    }
-  }, {
-    key: "useTypeScript",
-    get: function get() {
-      return this._config.useTypeScript;
-    }
-  }, {
-    key: "extension",
-    get: function get() {
-      return this._config.useTypeScript ? 'ts' : 'js';
     }
   }]);
 

--- a/dist/compiled/main.js
+++ b/dist/compiled/main.js
@@ -5,6 +5,10 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = main;
 
+require("core-js/stable");
+
+require("regenerator-runtime/runtime");
+
 var _path = _interopRequireDefault(require("path"));
 
 var _swaggerClient = _interopRequireDefault(require("swagger-client"));
@@ -67,15 +71,16 @@ function _main() {
                   if (!_lodash.default.isObject(operation)) {
                     console.warn("not processed. path:".concat(path, ", method:").concat(method));
                     return;
-                  } // @ts-expect-error
+                  } // @ts-expect-error operationIdがあると認識されていない
 
 
-                  if (operation.operationId) {
-                    console.info( // @ts-expect-error
-                    "no use specified operationId. path:".concat(path, ", method:").concat(method, ", operationId:").concat(operation.operationId)); // @ts-expect-error
+                  var operationId = operation.operationId;
+
+                  if (operationId) {
+                    console.info("no use specified operationId. path:".concat(path, ", method:").concat(method, ", operationId:").concat(operationId)); // @ts-expect-error operationIdがあると認識されていない
 
                     delete operation.operationId;
-                  } // @ts-expect-error
+                  } // @ts-expect-error responsesがあると認識されていない
 
 
                   var response = operation.responses;

--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -93,11 +93,7 @@ var ModelGenerator = /*#__PURE__*/function () {
 
 
       var requiredPropertyNames = this.definitions[name] && this.definitions[name].required;
-      var nullablePropertyNames = Object.keys(properties).filter(function (propertyName) {
-        return properties[propertyName].nullable;
-      });
       var appliedProperties = (0, _utils.applyRequired)(properties, requiredPropertyNames);
-      appliedProperties = (0, _utils.applyNullable)(appliedProperties, nullablePropertyNames);
       return this._renderBaseModel(name, appliedProperties, idAttribute).then(function (_ref2) {
         var text = _ref2.text,
             props = _ref2.props;

--- a/dist/compiled/schema_generator.js
+++ b/dist/compiled/schema_generator.js
@@ -144,11 +144,10 @@ var SchemaGenerator = /*#__PURE__*/function () {
     value: function write() {
       var _this2 = this;
 
-      // @ts-expect-error
       return Promise.all([this._writeSchemaFile()].concat(_toConsumableArray(this.importModels.map(function (_ref3) {
         var modelName = _ref3.modelName,
             model = _ref3.model;
-        return (// @ts-expect-error
+        return (// @ts-expect-error utilsのgetModelNameで生成されるmodelNameがundefinedの可能性がある
           _this2.modelGenerator.writeModel(model, modelName)
         );
       })))).then(function () {
@@ -170,7 +169,7 @@ var SchemaGenerator = /*#__PURE__*/function () {
           schema = _this$templates.schema,
           head = _this$templates.head,
           oneOf = _this$templates.oneOf;
-      if (!schema || !head || !oneOf) return;
+      if (!schema || !head || !oneOf) return Promise.reject();
       var text = (0, _utils.render)(schema, {
         importList: this._prepareImportList(),
         data: (0, _utils.objectToTemplateValue)(this.formattedSchema),

--- a/dist/compiled/spec_file_utils.js
+++ b/dist/compiled/spec_file_utils.js
@@ -104,7 +104,7 @@ function getPreparedSpec() {
   var readFiles = {};
   var allFiles = (0, _uniq.default)(getAllRelatedFiles(specFiles));
   return _merge.default.apply(void 0, [{}].concat(_toConsumableArray(specFiles.concat(allFiles).map(function (p) {
-    var spec = _jsYaml.default.safeLoad(_fs.default.readFileSync(p).toString());
+    var spec = _jsYaml.default.load(_fs.default.readFileSync(p).toString());
 
     if (isDocument(spec)) {
       if (specFiles.includes(p)) {
@@ -136,6 +136,7 @@ function getPreparedSpec() {
 
   function removeUnusableOperation(spec) {
     (0, _each.default)(spec.paths, function (operations) {
+      if (!operations) return;
       (0, _each.default)(operations, function (operation, method) {
         if (isOperation(operation) && isMethodName(method) && !isUsableOperation(operation.tags)) {
           delete operations[method];
@@ -146,7 +147,7 @@ function getPreparedSpec() {
 
   function getAllRelatedFiles(files) {
     return files.reduce(function (acc, filePath) {
-      var spec = _jsYaml.default.safeLoad(_fs.default.readFileSync(filePath).toString());
+      var spec = _jsYaml.default.load(_fs.default.readFileSync(filePath).toString());
 
       var refFilesPaths = isDocument(spec) ? (0, _uniq.default)(getRefFilesPath(spec)) : [];
       var relatedFilesPaths = (0, _flatten.default)(refFilesPaths.map(function (p) {

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -9,7 +9,6 @@ exports.applyIf = applyIf;
 exports.parseSchema = parseSchema;
 exports.isFileExistPromise = isFileExistPromise;
 exports.applyRequired = applyRequired;
-exports.applyNullable = applyNullable;
 exports.resolvePath = resolvePath;
 exports.mkdirpPromise = mkdirpPromise;
 exports.writeFilePromise = writeFilePromise;
@@ -170,22 +169,6 @@ function applyRequired(props, requiredList) {
 
     if (requiredList.includes(key)) {
       prop.required = true;
-    }
-
-    return ret;
-  }, {});
-}
-
-function applyNullable(props, nullableList) {
-  if (!_lodash.default.isArray(nullableList)) {
-    return props;
-  }
-
-  return _lodash.default.reduce(props, function (ret, prop, key) {
-    ret[key] = prop;
-
-    if (nullableList.includes(key)) {
-      prop.nullable = true;
     }
 
     return ret;

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -9,6 +9,7 @@ exports.applyIf = applyIf;
 exports.parseSchema = parseSchema;
 exports.isFileExistPromise = isFileExistPromise;
 exports.applyRequired = applyRequired;
+exports.applyNullable = applyNullable;
 exports.resolvePath = resolvePath;
 exports.mkdirpPromise = mkdirpPromise;
 exports.writeFilePromise = writeFilePromise;
@@ -109,17 +110,17 @@ function parseSchema(schema, onSchema) {
     return onSchema({
       type: 'model',
       value: schema
-    }); // @ts-expect-error
+    }); // @ts-expect-error oneOfやdiscriminatorがあると認識されていない
   } else if (schema.oneOf && schema.discriminator) {
     return onSchema({
       type: 'oneOf',
       value: parseOneOf(schema, onSchema)
-    }); // @ts-expect-error
+    }); // @ts-expect-error typeがあると認識されていない
   } else if (schema.type === 'object') {
-    // @ts-expect-error
-    return applyIf(parseSchema(schema.properties, onSchema)); // @ts-expect-error
+    // @ts-expect-error propertiesがあると認識されていない
+    return applyIf(parseSchema(schema.properties, onSchema)); // @ts-expect-error typeがあると認識されていない
   } else if (schema.type === 'array') {
-    // @ts-expect-error
+    // @ts-expect-error itemsがあると認識されていない
     return applyIf(parseSchema(schema.items, onSchema), function (val) {
       return [val];
     });
@@ -168,6 +169,22 @@ function applyRequired(props, requiredList) {
     ret[key] = prop;
 
     if (requiredList.includes(key)) {
+      prop.required = true;
+    }
+
+    return ret;
+  }, {});
+}
+
+function applyNullable(props, nullableList) {
+  if (!_lodash.default.isArray(nullableList)) {
+    return props;
+  }
+
+  return _lodash.default.reduce(props, function (ret, prop, key) {
+    ret[key] = prop;
+
+    if (nullableList.includes(key)) {
       prop.required = true;
     }
 

--- a/dist/compiled/utils.js
+++ b/dist/compiled/utils.js
@@ -185,7 +185,7 @@ function applyNullable(props, nullableList) {
     ret[key] = prop;
 
     if (nullableList.includes(key)) {
-      prop.required = true;
+      prop.nullable = true;
     }
 
     return ret;

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -276,11 +276,11 @@ export default {
             \\"type\\": \\"string\\"
           },
           \\"nickname\\": {
-            \\"type\\": \\"string\\"
-          },
-          \\"address\\": {
             \\"type\\": \\"string\\",
             \\"nullable\\": true
+          },
+          \\"address\\": {
+            \\"type\\": \\"string\\"
           },
           \\"gender\\": {
             \\"type\\": \\"string\\",
@@ -406,8 +406,8 @@ export type GenderOther = 'other';
 
 export interface OwnerProps {
   name?: string;
-  nickname: string | undefined;
-  address: string | null | undefined;
+  nickname: string | null | undefined;
+  address: string | undefined;
   gender?: GenderMale | GenderFemale | GenderOther;
 };
 
@@ -652,11 +652,11 @@ export default {
             \\"type\\": \\"string\\"
           },
           \\"nickname\\": {
-            \\"type\\": \\"string\\"
-          },
-          \\"address\\": {
             \\"type\\": \\"string\\",
             \\"nullable\\": true
+          },
+          \\"address\\": {
+            \\"type\\": \\"string\\"
           },
           \\"gender\\": {
             \\"type\\": \\"string\\",

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -47,6 +47,8 @@ export const GENDER_OTHER = 'other';
 
 const defaultValues = {
   name: undefined,
+  nickname: undefined,
+  address: undefined,
   gender: undefined,
 };
 
@@ -265,9 +267,20 @@ export default {
       },
       \\"Owner\\": {
         \\"type\\": \\"object\\",
+        \\"required\\": [
+          \\"nickname\\",
+          \\"address\\"
+        ],
         \\"properties\\": {
           \\"name\\": {
             \\"type\\": \\"string\\"
+          },
+          \\"nickname\\": {
+            \\"type\\": \\"string\\"
+          },
+          \\"address\\": {
+            \\"type\\": \\"string\\",
+            \\"nullable\\": true
           },
           \\"gender\\": {
             \\"type\\": \\"string\\",
@@ -393,11 +406,15 @@ export type GenderOther = 'other';
 
 export interface OwnerProps {
   name?: string;
+  nickname: string | undefined;
+  address: string | null | undefined;
   gender?: GenderMale | GenderFemale | GenderOther;
 };
 
 const defaultValues: OwnerProps = {
   name: undefined,
+  nickname: undefined,
+  address: undefined,
   gender: undefined,
 };
 
@@ -626,9 +643,20 @@ export default {
       },
       \\"Owner\\": {
         \\"type\\": \\"object\\",
+        \\"required\\": [
+          \\"nickname\\",
+          \\"address\\"
+        ],
         \\"properties\\": {
           \\"name\\": {
             \\"type\\": \\"string\\"
+          },
+          \\"nickname\\": {
+            \\"type\\": \\"string\\"
+          },
+          \\"address\\": {
+            \\"type\\": \\"string\\",
+            \\"nullable\\": true
           },
           \\"gender\\": {
             \\"type\\": \\"string\\",

--- a/spec/json_schema_ref.yml
+++ b/spec/json_schema_ref.yml
@@ -86,10 +86,10 @@ components:
         nickname:
           description: owner's nickname
           type: string
+          nullable: true
         address:
           description: owner's address
           type: string
-          nullable: true
         gender:
           description: owner's gender
           type: string

--- a/spec/json_schema_ref.yml
+++ b/spec/json_schema_ref.yml
@@ -75,11 +75,21 @@ components:
             - Cat
     Owner:
       type: object
+      required:
+        - nickname
+        - address
       x-id-attribute: name
       properties:
         name:
           description: owner's name
           type: string
+        nickname:
+          description: owner's nickname
+          type: string
+        address:
+          description: owner's address
+          type: string
+          nullable: true
         gender:
           description: owner's gender
           type: string

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -7,7 +7,6 @@ import {
   render,
   objectToTemplateValue,
   applyRequired,
-  applyNullable,
   getIdAttribute,
   readTemplates,
   isFileExistPromise,
@@ -100,12 +99,7 @@ export default class ModelGenerator {
 
     // requiredはモデル定義のものを使う
     const requiredPropertyNames = this.definitions[name] && this.definitions[name].required;
-    const nullablePropertyNames = Object.keys(properties).filter(
-      (propertyName) => properties[propertyName].nullable,
-    );
-
-    let appliedProperties = applyRequired(properties, requiredPropertyNames);
-    appliedProperties = applyNullable(appliedProperties, nullablePropertyNames);
+    const appliedProperties = applyRequired(properties, requiredPropertyNames);
 
     return this._renderBaseModel(name, appliedProperties, idAttribute).then(
       ({ text, props }: TODO) => {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -141,6 +141,23 @@ export function applyRequired(props: TODO, requiredList: TODO[]) {
   );
 }
 
+export function applyNullable(props: TODO, nullableList: TODO[]) {
+  if (!_.isArray(nullableList)) {
+    return props;
+  }
+  return _.reduce(
+    props,
+    (ret: { [key: string]: TODO }, prop, key) => {
+      ret[key] = prop;
+      if (nullableList.includes(key)) {
+        prop.required = true;
+      }
+      return ret;
+    },
+    {},
+  );
+}
+
 export function resolvePath(str: string) {
   return path.isAbsolute(str) ? str : path.join(cwd, str);
 }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -150,7 +150,7 @@ export function applyNullable(props: TODO, nullableList: TODO[]) {
     (ret: { [key: string]: TODO }, prop, key) => {
       ret[key] = prop;
       if (nullableList.includes(key)) {
-        prop.required = true;
+        prop.nullable = true;
       }
       return ret;
     },

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -141,23 +141,6 @@ export function applyRequired(props: TODO, requiredList: TODO[]) {
   );
 }
 
-export function applyNullable(props: TODO, nullableList: TODO[]) {
-  if (!_.isArray(nullableList)) {
-    return props;
-  }
-  return _.reduce(
-    props,
-    (ret: { [key: string]: TODO }, prop, key) => {
-      ret[key] = prop;
-      if (nullableList.includes(key)) {
-        prop.nullable = true;
-      }
-      return ret;
-    },
-    {},
-  );
-}
-
 export function resolvePath(str: string) {
   return path.isAbsolute(str) ? str : path.join(cwd, str);
 }

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -25,7 +25,7 @@ export type {{literalTypeName}} = {{#isValueString}}'{{value}}'{{/isValueString}
 
 export interface {{name}}Props {
 {{#props}}
-  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}};
+  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#required}} | undefined{{/required}}{{#nullable}} | null{{/nullable}};
 {{/props}}
 };
 

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -25,7 +25,7 @@ export type {{literalTypeName}} = {{#isValueString}}'{{value}}'{{/isValueString}
 
 export interface {{name}}Props {
 {{#props}}
-  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#required}} | undefined{{/required}}{{#nullable}} | null{{/nullable}};
+  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}}{{#required}} | undefined{{/required}};
 {{/props}}
 };
 

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -25,7 +25,7 @@ export type {{literalTypeName}} = {{#isValueString}}'{{value}}'{{/isValueString}
 
 export interface {{name}}Props {
 {{#props}}
-  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#required}} | undefined{{/required}};
+  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}};
 {{/props}}
 };
 
@@ -39,7 +39,7 @@ const defaultValues{{#useTypeScript}}: {{name}}Props{{/useTypeScript}} = {
 {{#usePropTypes}}
 export const propTypesObject = {
 {{#props}}
-  {{&name}}: {{&getPropTypes}}{{#required}}.isRequired{{/required}},
+  {{&name}}: {{&getPropTypes}}{{#required}}{{^nullable}}.isRequired{{/nullable}}{{/required}},
 {{/props}}
 };
 export const propTypes = PropTypes.shape(propTypesObject);


### PR DESCRIPTION
APIのスキーマ定義でModelのproperty Aがrequiredあった場合、nullableでもpropTypesにA.isRequiredがついてしまう。
これはnullableというデータをそもそも見ていなかったため。
そこでnullable属性を追加し、requiredでもnullableであった場合はisRequiredを付けないようにする

![image](https://user-images.githubusercontent.com/7846521/108034518-fbee0a80-7078-11eb-8bad-751b7eea4852.png)
