### PR TITLE
Add record property types

### DIFF
--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -255,25 +255,35 @@ var ModelGenerator = /*#__PURE__*/function () {
       var _this4 = this;
 
       var dependencySchema = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-      return _lodash.default.map(properties, function (prop, _name) {
+
+      var aliasNames = _lodash.default.map(properties, function (prop) {
+        return prop['x-attribute-as'];
+      });
+
+      return _lodash.default.map(properties, function (prop, name) {
+        var baseName = _this4.attributeConverter(name);
+
         var base = {
           name: function name() {
-            return _this4.attributeConverter(_name);
+            return baseName;
           },
-          type: _this4.generateTypeFrom(prop, dependencySchema[_name]),
+          type: _this4.generateTypeFrom(prop, dependencySchema[name]),
+          // x-attribute-asで参照している先のプロパティ名
           alias: prop['x-attribute-as'],
+          // nameがx-attribute-asで参照されているプロパティかどうか
+          isAliasBase: aliasNames.includes(name),
           required: prop.required === true,
           nullable: prop.nullable === true,
           isEnum: Boolean(prop.enum),
           isValueString: prop.type === 'string',
-          propertyName: _name,
-          enumObjects: _this4.getEnumObjects(_this4.attributeConverter(_name), prop.enum, prop['x-enum-key-attributes']),
+          propertyName: name,
+          enumObjects: _this4.getEnumObjects(baseName, prop.enum, prop['x-enum-key-attributes']),
           enumType: _this4._getEnumTypes(prop.type),
           items: prop.items
         }; // @ts-expect-error プロパティ 'templatePropNames' は型 'Function' に存在しません。
 
         return _this4.constructor.templatePropNames.reduce(function (ret, key) {
-          ret[key] = ret[key] || properties[_name][key];
+          ret[key] = ret[key] || properties[name][key];
           return ret;
         }, base);
       });

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -432,6 +432,11 @@ const denormalize = (
 };
 
 export default class Owner extends Record(defaultValues) {
+  name?: string;
+  nickname: string | null | undefined;
+  address: string | undefined;
+  gender?: GenderMale | GenderFemale | GenderOther;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -493,6 +498,11 @@ const denormalize = (
 };
 
 export default class WrappedPet extends Record(defaultValues) {
+  id: number | undefined;
+  name: string | undefined;
+  kind: KindDog | KindCat | undefined;
+  owner: Owner | undefined;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -1224,6 +1234,10 @@ const denormalize = (
 };
 
 export default class Cat extends Record(defaultValues) {
+  id: number | undefined;
+  kind: KindCat | undefined;
+  name?: string;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -1277,6 +1291,10 @@ const denormalize = (
 };
 
 export default class Dog extends Record(defaultValues) {
+  id: number | undefined;
+  kind: KindDog | undefined;
+  name?: string;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -1339,6 +1357,10 @@ const denormalize = (
 };
 
 export default class Owner extends Record(defaultValues) {
+  name: string | undefined;
+  fallback_title?: string;
+  pet?: Dog | Cat;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -2010,6 +2032,10 @@ const denormalize = (
 };
 
 export default class Cat extends Record(defaultValues) {
+  id: number | undefined;
+  kind: KindCat | undefined;
+  name?: string;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any
@@ -2063,6 +2089,10 @@ const denormalize = (
 };
 
 export default class Dog extends Record(defaultValues) {
+  id: number | undefined;
+  kind: KindDog | undefined;
+  name?: string;
+
   static denormalize(
     id: number | string | Array<number> | Array<string> | List<number> | List<string>,
     entities: any

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -1370,7 +1370,6 @@ export default class Owner extends Record(defaultValues) {
 
   // created by 'x-attribute-as'
   get title() {
-    // @ts-expect-error generated from API definition file
     return this.get('title', this.fallback_title);
   }
 }

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -224,21 +224,22 @@ export default class ModelGenerator {
   }
 
   _convertPropForTemplate(properties: TODO, dependencySchema: { [key: string]: TODO } = {}) {
+    const aliasNames = _.map(properties, (prop) => prop['x-attribute-as']);
     return _.map(properties, (prop, name) => {
+      const baseName = this.attributeConverter(name);
       const base = {
-        name: () => this.attributeConverter(name),
+        name: () => baseName,
         type: this.generateTypeFrom(prop, dependencySchema[name]),
+        // x-attribute-asで参照している先のプロパティ名
         alias: prop['x-attribute-as'],
+        // nameがx-attribute-asで参照されているプロパティかどうか
+        isAliasBase: aliasNames.includes(name),
         required: prop.required === true,
         nullable: prop.nullable === true,
         isEnum: Boolean(prop.enum),
         isValueString: prop.type === 'string',
         propertyName: name,
-        enumObjects: this.getEnumObjects(
-          this.attributeConverter(name),
-          prop.enum,
-          prop['x-enum-key-attributes'],
-        ),
+        enumObjects: this.getEnumObjects(baseName, prop.enum, prop['x-enum-key-attributes']),
         enumType: this._getEnumTypes(prop.type),
         items: prop.items,
       };

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -80,8 +80,7 @@ export default class {{name}} extends Record(defaultValues) {
 
   // created by 'x-attribute-as'
   get {{&alias}}() {
-{{#useTypeScript}}    // @ts-expect-error generated from API definition file
-{{/useTypeScript}}    return this.get('{{&alias}}', this.{{name}});
+    return this.get('{{&alias}}', this.{{name}});
   }
 {{/alias}}
 {{/props}}

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -61,6 +61,14 @@ const denormalize = (
 };
 
 export default class {{name}} extends Record(defaultValues) {
+{{#useTypeScript}}
+{{#props}}
+{{^isAliasBase}}
+  {{&name}}{{^required}}?{{/required}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}}{{#required}} | undefined{{/required}};
+{{/isAliasBase}}
+{{/props}}
+
+{{/useTypeScript}}
   static denormalize(
     id{{#useTypeScript}}: number | string | Array<number> | Array<string> | List<number> | List<string>{{/useTypeScript}},
     entities{{#useTypeScript}}: any{{/useTypeScript}}


### PR DESCRIPTION
Add record property types to ts models.

understanding

|before|after|
|-|-|
|![image](https://user-images.githubusercontent.com/7846521/109767763-625b5700-7c3b-11eb-8451-ef36064e9848.png)|![image](https://user-images.githubusercontent.com/7846521/109767618-27f1ba00-7c3b-11eb-8561-47446b75946a.png)|


Exclude alias base property (avoid duplicate declaration) ↓
![image](https://user-images.githubusercontent.com/7846521/109767979-a4849880-7c3b-11eb-81b5-b0bdbea413d9.png)
