### PR TITLE
Fix node-fetch version because of security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
   },
   "resolutions": {
     "json-schema": ">=0.4.0",
-    "jsonpointer": ">=5.0.0"
+    "jsonpointer": ">=5.0.0",
+    "node-fetch": "^2.6.7"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5119,12 +5119,7 @@ node-domexception@1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
dependabot security alert

![image](https://user-images.githubusercontent.com/7846521/150711075-5cae2d43-8ecc-4fda-8938-cc053f23d105.png)

![image](https://user-images.githubusercontent.com/7846521/150710337-3e5e6685-c0c8-4282-b46e-9524b8ef1df5.png)

>  The latest possible version that can be installed is 2.6.1 because of the following conflicting dependency:

> swagger-client@3.18.2 requires node-fetch@2.6.1 via cross-fetch@3.1.4
The earliest fixed version is 2.6.7.

---

swagger-clientは最新バージョンのため、yarnのresolutionsを使ってnode-fetchのバージョンを2.6.7以上にする

Since swagger-client is the latest version, use yarn resolutions to set the node-fetch version to 2.6.7 or higher.
