### PR TITLE
Revert resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
   },
   "resolutions": {
     "json-schema": ">=0.4.0",
-    "jsonpointer": ">=5.0.0",
-    "node-fetch": "^2.6.7"
+    "jsonpointer": ">=5.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
本体が対応されたため、https://github.com/eightcard/openapi-to-normalizr/pull/1196 の対応を戻す。