### PR TITLE
Add shouldSkipPreviousRequest flag

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,7 +32,7 @@ const TimelineContainer = () => {
     dispatch(getTimeline());
   }, [dispatch]);
 
-  return <Timeline timeline={timeline} onRequestDelete={handleRequestDelete} />;
+  return <Timeline timeline={timeline.reverse()} onRequestDelete={handleRequestDelete} />;
 };
 
 const App = () => {

--- a/src/lib/entities-reducer.ts
+++ b/src/lib/entities-reducer.ts
@@ -9,6 +9,10 @@ export function resetMetaCreator() {
   return { reset: true } as const;
 }
 
+export function shouldIgnorePreviousRequestMetaCreator() {
+  return { shouldIgnorePreviousRequest: true } as const;
+}
+
 type State = Map<string, TODO>;
 
 /**

--- a/src/lib/entities-reducer.ts
+++ b/src/lib/entities-reducer.ts
@@ -9,8 +9,8 @@ export function resetMetaCreator() {
   return { reset: true } as const;
 }
 
-export function shouldIgnorePreviousRequestMetaCreator() {
-  return { shouldIgnorePreviousRequest: true } as const;
+export function shouldSkipPreviousRequestMetaCreator() {
+  return { shouldSkipPreviousRequest: true } as const;
 }
 
 type State = Map<string, TODO>;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,9 @@
 import createMiddleware, { HttpClient as _HttpClient } from './redux-open-api';
-import { createReducer, resetMetaCreator as _resetMetaCreator } from './entities-reducer';
+import {
+  createReducer,
+  resetMetaCreator as _resetMetaCreator,
+  shouldIgnorePreviousRequestMetaCreator as _shouldIgnorePreviousRequestMetaCreator,
+} from './entities-reducer';
 
 import * as _immutable from 'immutable';
 import * as _normalizr from 'normalizr';
@@ -10,6 +14,7 @@ export const normalizr = _normalizr;
 export const createOpenApiMiddleware = createMiddleware;
 export const createEntitiesReducer = createReducer;
 export const resetMetaCreator = _resetMetaCreator;
+export const shouldIgnorePreviousRequestMetaCreator = _shouldIgnorePreviousRequestMetaCreator;
 export const HttpClient = _HttpClient;
 
 export default {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,7 @@ import createMiddleware, { HttpClient as _HttpClient } from './redux-open-api';
 import {
   createReducer,
   resetMetaCreator as _resetMetaCreator,
-  shouldIgnorePreviousRequestMetaCreator as _shouldIgnorePreviousRequestMetaCreator,
+  shouldSkipPreviousRequestMetaCreator as _shouldSkipPreviousRequestMetaCreator,
 } from './entities-reducer';
 
 import * as _immutable from 'immutable';
@@ -14,7 +14,7 @@ export const normalizr = _normalizr;
 export const createOpenApiMiddleware = createMiddleware;
 export const createEntitiesReducer = createReducer;
 export const resetMetaCreator = _resetMetaCreator;
-export const shouldIgnorePreviousRequestMetaCreator = _shouldIgnorePreviousRequestMetaCreator;
+export const shouldSkipPreviousRequestMetaCreator = _shouldSkipPreviousRequestMetaCreator;
 export const HttpClient = _HttpClient;
 
 export default {

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -63,17 +63,13 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
 
       return api(action.payload, Object.assign({}, options, httpOptions)).then(
         (response: { [key: string]: TODO } = {}) => {
-          // Whether it is the latest action of the same type to be called in parallel
-          /* eslint-disable no-undefined */
-          const isLatestRequest = shouldSkipPreviousRequest
-            ? latestTimestampMap[action.type] === timestamp
-            : undefined;
-          /* eslint-enable no-undefined */
+          const shouldSkip =
+            shouldSkipPreviousRequest && latestTimestampMap[action.type] !== timestamp;
 
           const useSchema = schema && (schema[response.status] || schema['default']);
           const payload = useSchema ? normalize(response.body, useSchema) : response.body;
 
-          if (shouldSkipPreviousRequest && !isLatestRequest) {
+          if (shouldSkip) {
             // eslint-disable-next-line callback-return
             next({
               type: `SKIPPED_${action.type}`,

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -18,7 +18,7 @@ function getShouldSkipPreviousRequest(action?: { meta?: { shouldSkipPreviousRequ
 export const HttpClient = Swagger.http;
 
 /**
- * action.typeがkey、DateをvalueOf()した値がvalueのマップ
+ * { [key: action.type]: Date.valueOf() }
  */
 const latestTimestampMap: Record<string, number> = {};
 
@@ -63,8 +63,7 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
 
       return api(action.payload, Object.assign({}, options, httpOptions)).then(
         (response: { [key: string]: TODO } = {}) => {
-          // 並行してリクエストしているactionのうち、同じtypeのものの中で最後に呼び出されたactionかどうか
-          // shouldSkipPreviousRequest: trueの場合のみチェックする
+          // Whether it is the latest action of the same type to be called in parallel
           /* eslint-disable no-undefined */
           const isLatestRequest = shouldSkipPreviousRequest
             ? latestTimestampMap[action.type] === timestamp
@@ -74,7 +73,6 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
           const useSchema = schema && (schema[response.status] || schema['default']);
           const payload = useSchema ? normalize(response.body, useSchema) : response.body;
 
-          // shouldSkipPreviousRequest: trueの場合は、最新のリクエストの場合のみnextを呼ぶ
           if (!shouldSkipPreviousRequest || isLatestRequest) {
             // eslint-disable-next-line callback-return
             next({

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -80,6 +80,14 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
               meta: action.meta,
               payload,
             });
+          } else {
+            // eslint-disable-next-line callback-return
+            next({
+              type: `SKIPPED_${action.type}`,
+              meta: action.meta,
+              payload,
+              skipped: true,
+            });
           }
           return response;
         },

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -20,7 +20,7 @@ function getShouldIgnorePreviousRequest(action?: {
 export const HttpClient = Swagger.http;
 
 /**
- * action.typeとDateをvalueOf()したもの
+ * action.typeがkey、DateをvalueOf()した値がvalueのマップ
  */
 const latestTimestampMap: Record<string, number> = {};
 

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -75,7 +75,6 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
               type: `SKIPPED_${action.type}`,
               meta: action.meta,
               payload,
-              skipped: true,
             });
           } else {
             // eslint-disable-next-line callback-return

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -73,7 +73,6 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
           const useSchema = schema && (schema[response.status] || schema['default']);
           const payload = useSchema ? normalize(response.body, useSchema) : response.body;
 
-
           if (shouldSkipPreviousRequest && !isLatestRequest) {
             // eslint-disable-next-line callback-return
             next({

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -73,20 +73,21 @@ export default (spec: TODO, httpOptions?: Record<string, TODO>): TODO => {
           const useSchema = schema && (schema[response.status] || schema['default']);
           const payload = useSchema ? normalize(response.body, useSchema) : response.body;
 
-          if (!shouldSkipPreviousRequest || isLatestRequest) {
-            // eslint-disable-next-line callback-return
-            next({
-              type: action.type,
-              meta: action.meta,
-              payload,
-            });
-          } else {
+
+          if (shouldSkipPreviousRequest && !isLatestRequest) {
             // eslint-disable-next-line callback-return
             next({
               type: `SKIPPED_${action.type}`,
               meta: action.meta,
               payload,
               skipped: true,
+            });
+          } else {
+            // eslint-disable-next-line callback-return
+            next({
+              type: action.type,
+              meta: action.meta,
+              payload,
             });
           }
           return response;

--- a/src/lib/redux-open-api.ts
+++ b/src/lib/redux-open-api.ts
@@ -11,7 +11,9 @@ function isOpenApiAction(action: TODO) {
   return action && action.meta && action.meta.openApi;
 }
 
-function getShouldIgnorePreviousRequest(action: TODO) {
+function getShouldIgnorePreviousRequest(action?: {
+  meta?: { shouldIgnorePreviousRequest?: boolean };
+}) {
   return Boolean(action && action.meta && action.meta.shouldIgnorePreviousRequest);
 }
 


### PR DESCRIPTION
WIP解除条件

- [x] 他のアプリケーションのUIでの動作チェック、ローディング状態の確認


## 背景

Actionがほぼ同時刻に呼ばれた場合に、レスポンスの順番がリクエスト順番と異なる場合があり、表示結果が検索条件などと乖離してしまう場合がある。

そこで特定のflagを渡した場合、最後に呼ばれたActionのレスポンスの場合にmiddleware内で通常通りにnext()を呼ぶことにする。
それ以外の場合はSkipし、`SKIPPED_${action.type}`を呼び出す。ERRORの実装と合わせています。

画像
<img width="1520" alt="スクリーンショット 2022-05-16 17 14 44" src="https://user-images.githubusercontent.com/7846521/168551065-f3cb65c6-18c5-4447-923b-464eb00eb790.png">


動作GIF
![Kapture 2022-05-16 at 17 13 43](https://user-images.githubusercontent.com/7846521/168551871-f525afc0-cf54-41dc-88f3-2ef6a6d720ce.gif)

