### PR TITLE
Downgrade swagger-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "4.17.21",
     "mkdirp": "1.0.4",
     "mustache": "4.2.0",
-    "swagger-client": "3.18.5"
+    "swagger-client": "3.18.0"
   },
   "devDependencies": {
     "@babel/cli": "7.17.10",

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "extends": ["config:base", ":automergeMinor", ":maintainLockFilesWeekly"],
   "schedule": ["after 3pm and before 10pm on thursday"],
   "labels": ["renovate"],
-  "prHourlyLimit": 0
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "packageNames": ["swagger-client"],
+      "allowedVersions": "<= 3.18.0"
+    }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2386,6 +2386,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -2702,10 +2707,15 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.5.0, cookie@~0.5.0:
+cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   version "3.22.6"
@@ -2743,7 +2753,7 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-cross-fetch@^3.1.5:
+cross-fetch@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -2830,7 +2840,7 @@ deep-equal@^1.0.0:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-extend@^0.6.0:
+deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
@@ -2840,7 +2850,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2, deepmerge@~4.2.2:
+deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -6476,15 +6486,16 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-swagger-client@3.18.5:
-  version "3.18.5"
-  resolved "https://registry.yarnpkg.com/swagger-client/-/swagger-client-3.18.5.tgz#8034df561452f4bbd36871a8072394b7ca883106"
-  integrity sha512-c0txGDtfQTJnaIBaEKCwtRNcUaaAfj+RXI4QVV9p3WW+AUCQqp4naCjaDNNsOfMkE4ySyhnblbL+jGqAVC7snw==
+swagger-client@3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/swagger-client/-/swagger-client-3.18.0.tgz#2e59e666b38ded983e26fb512421ef8ff82547f0"
+  integrity sha512-lNfwTXHim0QiCNuZ4BKgWle7N7+9WlFLtcP02n0xSchFtdzsKJb2kWsOlwplRU3appVFjnHRy+1eVabRc3ZhbA==
   dependencies:
     "@babel/runtime-corejs3" "^7.11.2"
-    cookie "~0.5.0"
-    cross-fetch "^3.1.5"
-    deepmerge "~4.2.2"
+    btoa "^1.2.1"
+    cookie "~0.4.1"
+    cross-fetch "^3.1.4"
+    deep-extend "~0.6.0"
     fast-json-patch "^3.0.0-1"
     form-data-encoder "^1.4.3"
     formdata-node "^4.0.0"


### PR DESCRIPTION
An update of the swagger-client on which it depends has changed its behavior.
Therefore, downgrade and renovate to prevent automatic updates.

## Problem

When combining multiple schema etc. in `allOf`, the

"swagger-client": "3.18.0"

```js
Room [
  {
    modelName: 'UserVisitor',
    type: 'integer',
    enum: [ 1, 2 ],
    '__$ref__': '#/components/schemas/VisitorKind',
    'x-enum-key-attributes': [ 'user', 'corp' ],
    'x-model-name': 'VisitorKind',
    default: 1
  }
  {
    modelName: 'CorpVisitor',
    type: 'integer',
    enum: [ 1, 2 ],
    '__$ref__': '#/components/schemas/VisitorKind',
    'x-enum-key-attributes': [ 'user', 'corp' ],
    'x-model-name': 'VisitorKind',
    default: 2
  }
]
```

"swagger-client": "3.18.1"

```js
Room [
  {
    modelName: 'UserVisitor',
    type: 'integer',
    enum: [ 1, 2, 1, 1, 2 ], // increased
    '__$ref__': '#/components/schemas/VisitorKind',
    'x-enum-key-attributes': [ 'user', 'corp' ],
    'x-model-name': 'VisitorKind',
    default: 1
  }
  {
    modelName: 'CorpVisitor',
    type: 'integer',
    enum: [ 1, 2, 2, 1, 2 ], // increased
    '__$ref__': '#/components/schemas/VisitorKind',
    'x-enum-key-attributes': [ 'user', 'corp' ],
    'x-model-name': 'VisitorKind',
    default: 2
  }
]
```

As you can see above, the number of enums had increased.

The cause is
https://github.com/swagger-api/swagger-js/compare/v3.18.0...v3.18.1

> "deep-extend":"~0.6.0", -> "deepmerge":"~4.2.2",

Perhaps some parts were not merged properly before, but now they are all deepmerged properly.

