### PR TITLE
Update Cricle CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 base_image: &base_image
-  image: circleci/node:17.2.0
+  image: cimg/node:16.17.0
 
 jobs:
   npm_install:


### PR DESCRIPTION
babel-jest@29.0.0 がnode v17では利用できないためv16に落とす。 (v18はnative fetchの問題があるため)