### PR TITLE
Change the path of dependent Models from the base Model to the extended Model in the upper hierarchy.

### DIFF
--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -88,7 +88,7 @@ exports[`schema generator spec from json schema ref 3`] = `
 import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
-import { schema as OwnerSchema } from './owner';
+import { schema as OwnerSchema } from '../owner';
 
 export const KIND_DOG = 'Dog';
 export const KIND_CAT = 'Cat';
@@ -460,7 +460,7 @@ exports[`schema generator spec from json schema ref TS 3`] = `
 import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
-import Owner, { schema as OwnerSchema } from './owner';
+import Owner, { schema as OwnerSchema } from '../owner';
 
 export const KIND_DOG = 'Dog';
 export const KIND_CAT = 'Cat';
@@ -861,8 +861,8 @@ exports[`schema generator spec from one of check 4`] = `
 import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
-import { schema as DogSchema } from './dog';
-import { schema as CatSchema } from './cat';
+import { schema as DogSchema } from '../dog';
+import { schema as CatSchema } from '../cat';
 
 
 const defaultValues = {
@@ -1320,8 +1320,8 @@ exports[`schema generator spec from one of check TS 4`] = `
 import { Record, List } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
-import Dog, { schema as DogSchema } from './dog';
-import Cat, { schema as CatSchema } from './cat';
+import Dog, { schema as DogSchema } from '../dog';
+import Cat, { schema as CatSchema } from '../cat';
 
 
 

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -8,7 +8,7 @@ import { Record, List{{#useTypeScript}}{{#importImmutableMap}}, Map{{/importImmu
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 {{#importList}}
-import {{#useTypeScript}}{{name}}, {{/useTypeScript}}{ schema as {{schemaName}}{{#usePropTypes}}, propTypes as {{name}}PropType{{/usePropTypes}} } from './{{&filePath}}';
+import {{#useTypeScript}}{{name}}, {{/useTypeScript}}{ schema as {{schemaName}}{{#usePropTypes}}, propTypes as {{name}}PropType{{/usePropTypes}} } from '../{{&filePath}}';
 {{/importList}}
 
 {{#props}}


### PR DESCRIPTION
Modelが依存している別のModelのパスをbase Modelから上の階層にあるextendsしたModelに変える。

理由
- 実際にはbase Modelではなくextendsした方のModelでnormalizeされるため。
- extendsした方のModelにメソッドを生やした場合も認識されるようになる。

---

## 例

### before

```sh
models/
- base/
  - Person (base)
  - Contact (base)
    - userプロパティ: Person (base)
- Person (extended)
- Contact (extended)
  - someMethod
```

contact.user.someMethod <- someMethodが見つからない

### after

```sh
models/
- base/
  - Person (base)
  - Contact (base)
    - userプロパティ: Person (extended) <-- NEW
- Person (extended)
- Contact (extended)
  - someMethod
```

contact.user.someMethod <- someMethodが見つかる