### PR TITLE
Do not use `as const` for schemas file

### DIFF
--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -755,7 +755,7 @@ const schemas = {
   get_pets__id_: {
     200: WrappedPetSchema
   }
-} as const;
+};
 
 export default schemas;
 ",
@@ -1757,7 +1757,7 @@ const schemas = {
   get_owner__name_: {
     200: OwnerSchema
   }
-} as const;
+};
 
 export default schemas;
 ",
@@ -2505,7 +2505,7 @@ const schemas = {
   get_pets__id_: {
     200: oneOfSchema1
   }
-} as const;
+};
 
 export default schemas;
 ",

--- a/templates/schema_template.mustache
+++ b/templates/schema_template.mustache
@@ -7,6 +7,6 @@ import { schema as {{name}} } from './{{&path}}';
 
 {{>oneOf}}
 
-const schemas = {{&data}}{{#useTypeScript}} as const{{/useTypeScript}};
+const schemas = {{&data}};
 
 export default schemas;


### PR DESCRIPTION
With `as const`, the value would be readonly, and the type was too strict and wrong.

---

`as const`だとreadonlyな値になり、型が厳しすぎて間違っていた。