### PR TITLE
Fixed a bug that immutable Map was not imported in case of TS model

### DIFF
--- a/example/timeline.v3.yml
+++ b/example/timeline.v3.yml
@@ -162,6 +162,12 @@ components:
           format: int64
         logo:
           type: string
+        info:
+          type: object
+          properties:
+            admin:
+              type: object
+              $ref: '#/components/schemas/Person'
     Error:
       required:
         - code

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -413,7 +413,7 @@ exports[`schema generator spec from json schema ref TS 2`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 
@@ -491,7 +491,7 @@ exports[`schema generator spec from json schema ref TS 3`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 import Owner, { schema as OwnerSchema } from '../owner';
@@ -1289,7 +1289,7 @@ exports[`schema generator spec from one of check TS 2`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 
@@ -1360,7 +1360,7 @@ exports[`schema generator spec from one of check TS 3`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 
@@ -1431,7 +1431,7 @@ exports[`schema generator spec from one of check TS 4`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 import Dog, { schema as DogSchema } from '../dog';
@@ -2162,7 +2162,7 @@ exports[`schema generator spec from one of other spec file  check TS 2`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 
@@ -2233,7 +2233,7 @@ exports[`schema generator spec from one of other spec file  check TS 3`] = `
  * generated from API definition file
  */
 
-import { Record, List } from 'immutable';
+import { Record, List, Map } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -41,8 +41,6 @@ export default class ModelGenerator {
 
   _modelNameList: TODO[];
 
-  importImmutableMap: boolean;
-
   constructor({
     outputDir = '',
     outputBaseDir = '',
@@ -77,7 +75,6 @@ export default class ModelGenerator {
     this.writeModel = this.writeModel.bind(this);
     this.writeIndex = this.writeIndex.bind(this);
     this._modelNameList = [];
-    this.importImmutableMap = false;
   }
 
   /**
@@ -179,9 +176,6 @@ export default class ModelGenerator {
         }
       });
 
-      // reset
-      this.importImmutableMap = false;
-
       const props = {
         name,
         idAttribute: this._prepareIdAttribute(idAttribute),
@@ -199,7 +193,6 @@ export default class ModelGenerator {
         getPropTypes,
         getTypeScriptTypes,
         getDefaults,
-        importImmutableMap: this.importImmutableMap,
       };
 
       const { model, head, dependency, oneOf } = this.templates;
@@ -339,7 +332,6 @@ export default class ModelGenerator {
     }
 
     if (prop.type === 'object' && prop.properties) {
-      if (!this.importImmutableMap) this.importImmutableMap = true;
       const props = _.reduce(
         prop.properties,
         (acc: { [key: string]: TODO }, value, key) => {

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 {{/usePropTypes}}
-import { Record, List{{#useTypeScript}}{{#importImmutableMap}}, Map{{/importImmutableMap}}{{/useTypeScript}} } from 'immutable';
+import { Record, List{{#useTypeScript}}, Map{{/useTypeScript}} } from 'immutable';
 import { schema as _schema, denormalize as _denormalize } from 'normalizr';
 import isArray from 'lodash/isArray';
 {{#importList}}


### PR DESCRIPTION
TSのModelの場合にimmutable Mapがimportされないバグの修正

Modelのプロパティの型にimmutable Mapがあるとき、import文にMapが追加されるようになっている。
しかし、そのプロパティが別のModelへ参照持っているとき、import文へのMap追加

|before|after|
|-|-|
|![スクリーンショット 2022-12-15 16 16 03](https://user-images.githubusercontent.com/7846521/207798432-20c00280-c5d9-466b-9686-a8a3aa63248f.png)|![スクリーンショット 2022-12-15 16 18 12](https://user-images.githubusercontent.com/7846521/207798440-3c2cd790-9fcb-4305-a5da-9d3aeac34356.png)|
