### PR TITLE
Eliminate the possibility of undefined from required property types

### DIFF
--- a/example/timeline.v3.yml
+++ b/example/timeline.v3.yml
@@ -151,6 +151,8 @@ components:
     Company:
       description: |
         投稿者の企業モデル
+      required:
+        - id
       properties:
         publisherKind:
           type: number
@@ -162,6 +164,7 @@ components:
           format: int64
         logo:
           type: string
+          default: 'https://example.com/logo/default.png'
         info:
           type: object
           properties:

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -47,7 +47,9 @@ export const GENDER_OTHER = 'other';
 
 const defaultValues = {
   name: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   nickname: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   address: undefined,
   gender: undefined,
 };
@@ -94,9 +96,13 @@ export const KIND_DOG = 'Dog';
 export const KIND_CAT = 'Cat';
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   owner: undefined,
 };
 
@@ -415,14 +421,16 @@ export type GenderOther = 'other';
 
 export interface OwnerProps {
   name: string | undefined;
-  nickname: string | null | undefined;
-  address: string | undefined;
+  nickname: string | null;
+  address: string;
   gender: GenderMale | GenderFemale | GenderOther | undefined;
 };
 
 const defaultValues: OwnerProps = {
   name: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   nickname: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   address: undefined,
   gender: undefined,
 };
@@ -456,8 +464,10 @@ export const denormalize = <Model, Ids extends IdsBase>(
 
 export default class Owner extends Record(defaultValues) {
   name: string | undefined;
-  nickname: string | null | undefined;
-  address: string | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  nickname: string | null;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  address: string;
   gender: GenderMale | GenderFemale | GenderOther | undefined;
 
 }
@@ -485,16 +495,20 @@ export type KindDog = 'Dog';
 export type KindCat = 'Cat';
 
 export interface WrappedPetProps {
-  id: number | undefined;
-  name: string | undefined;
-  kind: KindDog | KindCat | undefined;
-  owner: Owner | undefined;
+  id: number;
+  name: string;
+  kind: KindDog | KindCat;
+  owner: Owner;
 };
 
 const defaultValues: WrappedPetProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   owner: undefined,
 };
 
@@ -529,10 +543,14 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class WrappedPet extends Record(defaultValues) {
-  id: number | undefined;
-  name: string | undefined;
-  kind: KindDog | KindCat | undefined;
-  owner: Owner | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  id: number;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  name: string;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  kind: KindDog | KindCat;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  owner: Owner;
 
 }
 ",
@@ -807,7 +825,9 @@ import isArray from 'lodash/isArray';
 export const KIND_CAT = 'cat';
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -852,7 +872,9 @@ import isArray from 'lodash/isArray';
 export const KIND_DOG = 'dog';
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -898,6 +920,7 @@ import { schema as CatSchema } from '../cat';
 
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
   title: undefined,
   fallback_title: undefined,
@@ -1256,13 +1279,15 @@ export const KIND_CAT = 'cat';
 export type KindCat = 'cat';
 
 export interface CatProps {
-  id: number | undefined;
-  kind: KindCat | undefined;
+  id: number;
+  kind: KindCat;
   name: string | undefined;
 };
 
 const defaultValues: CatProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -1295,8 +1320,10 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class Cat extends Record(defaultValues) {
-  id: number | undefined;
-  kind: KindCat | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  id: number;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  kind: KindCat;
   name: string | undefined;
 
 }
@@ -1321,13 +1348,15 @@ export const KIND_DOG = 'dog';
 export type KindDog = 'dog';
 
 export interface DogProps {
-  id: number | undefined;
-  kind: KindDog | undefined;
+  id: number;
+  kind: KindDog;
   name: string | undefined;
 };
 
 const defaultValues: DogProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -1360,8 +1389,10 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class Dog extends Record(defaultValues) {
-  id: number | undefined;
-  kind: KindDog | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  id: number;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  kind: KindDog;
   name: string | undefined;
 
 }
@@ -1386,13 +1417,14 @@ import Cat, { schema as CatSchema } from '../cat';
 
 
 export interface OwnerProps {
-  name: string | undefined;
+  name: string;
   title: string | undefined;
   fallback_title: string | undefined;
   pet: Dog | Cat | undefined;
 };
 
 const defaultValues: OwnerProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
   title: undefined,
   fallback_title: undefined,
@@ -1434,7 +1466,8 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class Owner extends Record(defaultValues) {
-  name: string | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  name: string;
   fallback_title: string | undefined;
   pet: Dog | Cat | undefined;
 
@@ -1749,7 +1782,9 @@ import isArray from 'lodash/isArray';
 export const KIND_CAT = 'cat';
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -1794,7 +1829,9 @@ import isArray from 'lodash/isArray';
 export const KIND_DOG = 'dog';
 
 const defaultValues = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -2099,13 +2136,15 @@ export const KIND_CAT = 'cat';
 export type KindCat = 'cat';
 
 export interface CatProps {
-  id: number | undefined;
-  kind: KindCat | undefined;
+  id: number;
+  kind: KindCat;
   name: string | undefined;
 };
 
 const defaultValues: CatProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -2138,8 +2177,10 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class Cat extends Record(defaultValues) {
-  id: number | undefined;
-  kind: KindCat | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  id: number;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  kind: KindCat;
   name: string | undefined;
 
 }
@@ -2164,13 +2205,15 @@ export const KIND_DOG = 'dog';
 export type KindDog = 'dog';
 
 export interface DogProps {
-  id: number | undefined;
-  kind: KindDog | undefined;
+  id: number;
+  kind: KindDog;
   name: string | undefined;
 };
 
 const defaultValues: DogProps = {
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -2203,8 +2246,10 @@ export const denormalize = <Model, Ids extends IdsBase>(
 };
 
 export default class Dog extends Record(defaultValues) {
-  id: number | undefined;
-  kind: KindDog | undefined;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  id: number;
+  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+  kind: KindDog;
   name: string | undefined;
 
 }

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -47,9 +47,7 @@ export const GENDER_OTHER = 'other';
 
 const defaultValues = {
   name: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   nickname: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   address: undefined,
   gender: undefined,
 };
@@ -96,13 +94,9 @@ export const KIND_DOG = 'Dog';
 export const KIND_CAT = 'Cat';
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   owner: undefined,
 };
 
@@ -825,9 +819,7 @@ import isArray from 'lodash/isArray';
 export const KIND_CAT = 'cat';
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -872,9 +864,7 @@ import isArray from 'lodash/isArray';
 export const KIND_DOG = 'dog';
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -920,7 +910,6 @@ import { schema as CatSchema } from '../cat';
 
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   name: undefined,
   title: undefined,
   fallback_title: undefined,
@@ -1782,9 +1771,7 @@ import isArray from 'lodash/isArray';
 export const KIND_CAT = 'cat';
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };
@@ -1829,9 +1816,7 @@ import isArray from 'lodash/isArray';
 export const KIND_DOG = 'dog';
 
 const defaultValues = {
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   id: undefined,
-  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   kind: undefined,
   name: undefined,
 };

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -192,6 +192,7 @@ export default class ModelGenerator {
         importList: this._prepareImportList(importList),
         getPropTypes,
         getTypeScriptTypes,
+        defaultIsUndefined,
         getDefaults,
       };
 
@@ -458,6 +459,11 @@ function _getTypeScriptTypes(type: TODO, enumObjects: TODO[]) {
     default:
       return type && type.typeScript ? type.typeScript : 'any';
   }
+}
+
+function defaultIsUndefined() {
+  // @ts-expect-error 'this' は型として注釈を持たないため、暗黙的に型 'any' になります。
+  return _.isUndefined(this.default);
 }
 
 function getDefaults() {

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -30,9 +30,10 @@ export interface {{name}}Props {
 };
 
 {{/useTypeScript}}
-const defaultValues = {
+const defaultValues{{#useTypeScript}}: {{name}}Props{{/useTypeScript}} = {
 {{#props}}
-  {{&name}}: {{&getDefaults}},
+{{#required}}{{#defaultIsUndefined}}  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+{{/defaultIsUndefined}}{{/required}}  {{&name}}: {{&getDefaults}},
 {{/props}}
 };
 

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -32,8 +32,8 @@ export interface {{name}}Props {
 {{/useTypeScript}}
 const defaultValues{{#useTypeScript}}: {{name}}Props{{/useTypeScript}} = {
 {{#props}}
-{{#required}}{{#defaultIsUndefined}}  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
-{{/defaultIsUndefined}}{{/required}}  {{&name}}: {{&getDefaults}},
+{{#useTypeScript}}{{#required}}{{#defaultIsUndefined}}  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+{{/defaultIsUndefined}}{{/required}}{{/useTypeScript}}  {{&name}}: {{&getDefaults}},
 {{/props}}
 };
 

--- a/templates/model_template.mustache
+++ b/templates/model_template.mustache
@@ -25,12 +25,12 @@ export type {{literalTypeName}} = {{#isValueString}}'{{value}}'{{/isValueString}
 
 export interface {{name}}Props {
 {{#props}}
-  {{&name}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}} | undefined;
+  {{&name}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}}{{^required}} | undefined{{/required}};
 {{/props}}
 };
 
 {{/useTypeScript}}
-const defaultValues{{#useTypeScript}}: {{name}}Props{{/useTypeScript}} = {
+const defaultValues = {
 {{#props}}
   {{&name}}: {{&getDefaults}},
 {{/props}}
@@ -80,7 +80,8 @@ export default class {{name}} extends Record(defaultValues) {
 {{#useTypeScript}}
 {{#props}}
 {{^isAliasBase}}
-  {{&name}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}} | undefined;
+{{#required}}  // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
+{{/required}}  {{&name}}: {{&getTypeScriptTypes}}{{#nullable}} | null{{/nullable}}{{^required}} | undefined{{/required}};
 {{/isAliasBase}}
 {{/props}}
 


### PR DESCRIPTION
requiredなプロパティの型からundefinedの可能性を排除する

作業
- exampleの拡張（前準備）
- requiredなプロパティからundefinedの可能性を排除するようにModelのテンプレートを修正
- Modelではrequiredなプロパティが正しく初期化されていないことがあるため、ts-expect-errorを付与する処理を追加

See (id)
|before|after|    
|-|-|
|![image](https://user-images.githubusercontent.com/7846521/209602952-df5ba433-eb0b-4a6d-85b6-c038a677a66e.png)|![image](https://user-images.githubusercontent.com/7846521/209602899-7a78056e-7616-4ded-8e24-33b4047280f0.png)|


---


Eliminate the possibility of undefined from required property types

Work
- Extension of example (preliminary work)
- Modified Model template to eliminate undefined possibilities from required properties
- Added process to add ts-expect-error to required properties since they are sometimes not initialized correctly in Model