### PR TITLE
Update API yaml lint rule

### DIFF
--- a/.spectral.json
+++ b/.spectral.json
@@ -1,8 +1,11 @@
 {
   "extends": ["spectral:oas"],
   "rules": {
+    "info-contact": false,
+    "no-$ref-siblings": false,
     "oas3-api-servers": false,
     "oas3-unused-component": false,
+    "oas3-valid-schema-example": "warn",
     "operation-tag-defined": false,
     "operation-operationId": false
   }

--- a/example/timeline.v3.yml
+++ b/example/timeline.v3.yml
@@ -18,7 +18,7 @@ paths:
       description: |
         投稿一覧を取得
       responses:
-        200:
+        '200':
           $ref: '#/components/responses/TimelineResponse'
     post:
       tags:
@@ -26,7 +26,7 @@ paths:
       description: ｜
         投稿を新規作成
       responses:
-        201:
+        '201':
           description: 投稿作成成功
           content:
             application/json:
@@ -52,7 +52,7 @@ paths:
       description: |
         指定されたIDに応じた投稿を取得
       responses:
-        200:
+        '200':
           description: 投稿取得成功
           content:
             application/json:
@@ -70,7 +70,7 @@ paths:
       description: |
         指定されたIDの投稿を削除
       responses:
-        200:
+        '200':
           description: 削除成功
         default:
           description: unexpected error
@@ -132,8 +132,8 @@ components:
           discriminator:
             propertyName: publisherKind
             mapping:
-              1: '#/components/schemas/Person'
-              2: '#/components/schemas/Company'
+              '1': '#/components/schemas/Person'
+              '2': '#/components/schemas/Company'
     Person:
       description: |
         投稿者の人物モデル

--- a/example/timeline.v3.yml
+++ b/example/timeline.v3.yml
@@ -6,6 +6,8 @@ info:
     name: API Support
     url: http://www.example.com/support
     email: support@example.com
+  description: |
+    タイムラインAPIの定義
 servers:
   - url: http://localhost:10010
 tags:

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "test": "npm-run-all lint jest",
     "jest": "jest src/lib spec",
     "lint": "run-p check:* eslint speclint",
-    "speclint": "spectral lint example/petstore.v3.yml spec/**/*.yml",
+    "speclint": "spectral lint example/timeline.v3.yml spec/**/*.yml",
     "example:api": "./example/serveViewer",
     "example:build": "./bin/generateschemas --config example/config/config.schemas.js example/timeline.v3.yml",
     "example:run": "cd example;yarn && yarn start",


### PR DESCRIPTION
[spectral](https://www.npmjs.com/package/@stoplight/spectral-cli)でAPI定義のLintをかけているが、指定しているexample内のyamlのファイル名が間違っていたので修正。

ルールも更新し、exampleの定義もルールに沿うように修正

---

Linted API definitions in [spectral](https://www.npmjs.com/package/@stoplight/spectral-cli), but the yaml filename in the example specified was incorrect, so it was corrected.

Updated that rule as well, and modified the example definitions to be in line with the rule.

