### PR TITLE
Update for Node 20

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/node": "16.18.46",
+    "@types/node": "20.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-redux": "8.1.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1992,10 +1992,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.6.tgz#5e9aaa86be03a09decafd61b128d6cec64a5fe40"
   integrity sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==
 
-"@types/node@16.18.46":
-  version "16.18.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.46.tgz#9f2102d0ba74a318fcbe170cbff5463f119eab59"
-  integrity sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==
+"@types/node@20.2.0":
+  version "20.2.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.0.tgz#e33da33171ac4eba79b9cfe30b68a4f1561e74ec"
+  integrity sha512-3iD2jaCCziTx04uudpJKwe39QxXgSUnpxXSvRQjRvHPxFQfmfP4NXIm/NURVeNlTCc+ru4WqjYGTmpXrW9uMlw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "openapi2schemas": "./bin/generateschemas"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "check:prettier": "prettier --check src example/src",
     "eslint": "eslint src bin/*",
     "mock": "cp example/initial_db.json example/db.json;json-server --watch example/db.json --port 10010",
-    "test": "npm-run-all lint jest",
+    "test": "NODE_OPTIONS='--no-experimental-fetch' npm-run-all lint jest",
     "jest": "jest src/lib spec",
     "lint": "run-p check:* eslint speclint",
     "speclint": "spectral lint example/timeline.v3.yml spec/**/*.yml",


### PR DESCRIPTION
Node 18からはネイティブでfetchをサポートするようになった。
通信のテストでserverのmock用に使っている[nock](https://github.com/nock/nock)はこれに対応できていない。
そのため、`--no-experimental-fetch` フラグを使って元通りに動くようにする。

ゆくゆくは、ネイティブfetchに対応したmockライブラリに載せ替える方が良い。

---

Since Node 18, fetch is natively supported.
The [nock](https://github.com/nock/nock) used for server mock in the communication test does not support this.
Therefore, use the `--no-experimental-fetch` flag to make it work as it was.

Eventually, it is better to replace it with a mock library that supports native fetch.
