### PR TITLE
Use corepack for yarn

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+          cache: 'yarn'
+      - run: corepack enable
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'yarn'
+      - run: corepack enable
       - run: yarn install --frozen-lockfile
       - run: yarn example:generate
       - run: yarn lint

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ node_modules
 tmp
 example/dist
 .vscode
+
+# yarn(zero-install)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -25,3 +25,12 @@ yarn-error.log*
 src/autoGen
 
 db.json
+
+# yarn(zero-install)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "type": "commonjs",
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "yarn@1.22.19+sha256.732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e",
   "scripts": {
     "start": "vite",
     "build": "vite build"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "engines": {
     "node": ">=20"
   },
+  "packageManager": "yarn@1.22.19+sha256.732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "10.1.0",
     "commander": "11.1.0",


### PR DESCRIPTION
yarnのバージョン管理を[corepack](https://github.com/nodejs/corepack)で行うように変更

---

Change to use [corepack](https://github.com/nodejs/corepack) for version control of yarn
