### PR TITLE
Fix enum unique logic

### DIFF
--- a/dist/compiled/model_generator.js
+++ b/dist/compiled/model_generator.js
@@ -284,8 +284,7 @@ var ModelGenerator = exports.default = /*#__PURE__*/function () {
       var _this5 = this;
       var enumKeyAttributes = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
       if (!enums) return false;
-      var uniqueEnums = Array.from(new Set(enums));
-      return uniqueEnums.map(function (current, index) {
+      var enumObjects = enums.map(function (current, index) {
         var enumName = enumKeyAttributes[index] || current;
         return {
           name: _this5.getEnumConstantName(enumName, name),
@@ -293,6 +292,14 @@ var ModelGenerator = exports.default = /*#__PURE__*/function () {
           value: current
         };
       });
+      var uniqueEnumObjects = enumObjects.filter(function (_ref6, index, array) {
+        var value = _ref6.value,
+          name = _ref6.name;
+        return index === array.findIndex(function (elem) {
+          return elem.value === value && elem.name === name;
+        });
+      });
+      return uniqueEnumObjects;
     }
   }, {
     key: "_getEnumTypes",
@@ -402,8 +409,8 @@ var ModelGenerator = exports.default = /*#__PURE__*/function () {
     }
   }, {
     key: "_renderOverrideModel",
-    value: function _renderOverrideModel(name, fileName, _ref6) {
-      var props = _ref6.props;
+    value: function _renderOverrideModel(name, fileName, _ref7) {
+      var props = _ref7.props;
       var enums = props.filter(function (prop) {
         return prop.enumObjects;
       }).reduce(function (acc, prop) {

--- a/spec/__snapshots__/command.test.ts.snap
+++ b/spec/__snapshots__/command.test.ts.snap
@@ -43,6 +43,7 @@ import isArray from 'lodash/isArray';
 
 export const GENDER_MALE = 'male';
 export const GENDER_FEMALE = 'female';
+export const GENDER_UNKNOWN = 'other';
 export const GENDER_OTHER = 'other';
 
 const defaultValues = {
@@ -246,7 +247,24 @@ export default {
             "$ref": "#/components/schemas/Pet/properties/kind"
           },
           "owner": {
-            "$ref": "#/components/schemas/Owner"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Owner"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "gender": {
+                    "type": "string",
+                    "enum": [
+                      "male",
+                      "female",
+                      "other"
+                    ]
+                  }
+                }
+              }
+            ]
           }
         }
       },
@@ -407,17 +425,19 @@ import isArray from 'lodash/isArray';
 
 export const GENDER_MALE = 'male';
 export const GENDER_FEMALE = 'female';
+export const GENDER_UNKNOWN = 'other';
 export const GENDER_OTHER = 'other';
 
 export type GenderMale = 'male';
 export type GenderFemale = 'female';
+export type GenderUnknown = 'other';
 export type GenderOther = 'other';
 
 export interface OwnerProps {
   name: string | undefined;
   nickname: string | null;
   address: string;
-  gender: GenderMale | GenderFemale | GenderOther | undefined;
+  gender: GenderMale | GenderFemale | GenderUnknown | GenderOther | undefined;
 };
 
 const defaultValues: OwnerProps = {
@@ -462,7 +482,7 @@ export default class Owner extends Record(defaultValues) {
   nickname: string | null;
   // @ts-expect-error Property has no initializer and is not definitely assigned in the constructor.ts(2564)
   address: string;
-  gender: GenderMale | GenderFemale | GenderOther | undefined;
+  gender: GenderMale | GenderFemale | GenderUnknown | GenderOther | undefined;
 
 }
 ",
@@ -669,7 +689,24 @@ export default {
             "$ref": "#/components/schemas/Pet/properties/kind"
           },
           "owner": {
-            "$ref": "#/components/schemas/Owner"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Owner"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "gender": {
+                    "type": "string",
+                    "enum": [
+                      "male",
+                      "female",
+                      "other"
+                    ]
+                  }
+                }
+              }
+            ]
           }
         }
       },

--- a/spec/json_schema_ref.yml
+++ b/spec/json_schema_ref.yml
@@ -56,7 +56,21 @@ components:
         kind:
           $ref: '#/components/schemas/Pet/properties/kind'
         owner:
-          $ref: '#/components/schemas/Owner'
+          allOf:
+            - $ref: '#/components/schemas/Owner'
+            - type: object
+              properties:
+                gender:
+                  description: owner's gender (another definition)
+                  type: string
+                  enum:
+                    - male
+                    - female
+                    - other
+                  x-enum-key-attributes:
+                    - male
+                    - female
+                    - unknown
     Pet:
       description: Pet
       type: object

--- a/src/tools/model_generator.ts
+++ b/src/tools/model_generator.ts
@@ -274,8 +274,7 @@ export default class ModelGenerator {
 
   getEnumObjects(name: string, enums?: TODO[], enumKeyAttributes: TODO[] = []) {
     if (!enums) return false;
-    const uniqueEnums = Array.from(new Set(enums));
-    return uniqueEnums.map((current, index) => {
+    const enumObjects = enums.map((current, index) => {
       const enumName = enumKeyAttributes[index] || current;
       return {
         name: this.getEnumConstantName(enumName, name),
@@ -283,6 +282,11 @@ export default class ModelGenerator {
         value: current,
       };
     });
+    const uniqueEnumObjects = enumObjects.filter(
+      ({ value, name }, index, array) =>
+        index === array.findIndex((elem) => elem.value === value && elem.name === name),
+    );
+    return uniqueEnumObjects;
   }
 
   _getEnumTypes(type: TODO) {


### PR DESCRIPTION
## 問題

swagger-clientのバージョンアップによってプロパティのdeep mergeの精度が上がり、enumのプロパティが重複するようになってしまったため、enumのvalueが被らないように[ユニーク処理を入れた](https://github.com/eightcard/openapi-to-normalizr/pull/2052/)が、`x-enum-key-attributes`なども考慮すると、valueだけ重複削除するのではダメだった。

## 例

具体的には、genderというenumプロパティを持つOwner schemaがあるとして、

![スクリーンショット 2025-01-08 13 06 48](https://github.com/user-attachments/assets/52ae14ac-01bc-405e-80ae-6bdb04c0a201)

genderという同名だけど一部定義が異なるenumプロパティを持つobjectと、OwnerをallOfでまとめているとする。

![スクリーンショット 2025-01-08 13 09 54](https://github.com/user-attachments/assets/13ee4072-aa02-4eea-ada8-24242f6a0f29)

この例ではOwnerのgenderのotherが、allOfの方のgenderではx-enum-key-attributesを使ったunknownという名前になっている。
（普通は使わないような定義ではありますが、今まではref先のプロパティまで生成できていなかったので、起きていた。）

このとき、生成されたModel内の、enumから生成される定数が一部重複するというバグがあった。

## 解決策

enumのvalueだけでなく、valueとnameを見て重複を削除する方針に変更。
それを確認するテストコードも追加。

プロダクションで問題ないことも確認済み。



