### PR TITLE
Use hash version for action

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,13 +8,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '22'
           cache: 'yarn'
       - run: corepack enable
-      - uses: preactjs/compressed-size-action@v2
+      - uses: preactjs/compressed-size-action@946a292cd35bd1088e0d7eb92b69d1a8d5b5d76a # 2.8.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           build-script: 'build:dist'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: '22'
           cache: 'yarn'


### PR DESCRIPTION
GitHub Actions security topic
- https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup

https://github.com/suzuki-shunsuke/pinact

- `pinact run`